### PR TITLE
Scos migration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ _GEM_INSTALL: &GEM_INSTALL
   - echo "_GEM_INSTALL"
   - gem install bundler
   - bundle install
-  - bundle exec jekyll build
+  - bundle exec jekyll build --config=_config.yml,_config_production.yml
 
 jobs:
   include:

--- a/Gemfile
+++ b/Gemfile
@@ -12,9 +12,12 @@ group :jekyll_plugins do
   gem "jekyll-feed", "~> 0.12"
   gem 'jekyll-sitemap'
   gem 'jekyll-last-modified-at'
+  gem 'jekyll-redirect-from'
+  gem 'jekyll-include-cache'
 end
 
 gem "rake"
+gem "liquid-c"
 
 # Windows and JRuby does not include zoneinfo files, so bundle the tzinfo-data gem
 # and associated library.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -74,9 +74,13 @@ GEM
       rouge (>= 2.0, < 4.0)
     jekyll-feed (0.15.1)
       jekyll (>= 3.7, < 5.0)
+    jekyll-include-cache (0.2.1)
+      jekyll (>= 3.7, < 5.0)
     jekyll-last-modified-at (1.3.0)
       jekyll (>= 3.7, < 5.0)
       posix-spawn (~> 0.3.9)
+    jekyll-redirect-from (0.16.0)
+      jekyll (>= 3.3, < 5.0)
     jekyll-sass-converter (2.1.0)
       sassc (> 2.0.1, < 3.0)
     jekyll-sitemap (1.4.0)
@@ -89,6 +93,8 @@ GEM
     kramdown-parser-gfm (1.1.0)
       kramdown (~> 2.0)
     liquid (4.0.3)
+    liquid-c (4.0.0)
+      liquid (>= 3.0.0)
     listen (3.5.1)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
@@ -147,8 +153,11 @@ DEPENDENCIES
   jekyll-algolia (~> 1.0)
   jekyll-commonmark-ghpages
   jekyll-feed (~> 0.12)
+  jekyll-include-cache
   jekyll-last-modified-at
+  jekyll-redirect-from
   jekyll-sitemap
+  liquid-c
   page_template_validator!
   rake
   tzinfo (~> 1.2)

--- a/_config.yml
+++ b/_config.yml
@@ -59,6 +59,8 @@ commonmark:
 plugins:
   - jekyll-feed
   - jekyll-last-modified-at
+  - jekyll-redirect-from
+  - jekyll-include-cache
 
 # filter used to process markdown. note that kramdown differs from github-flavored markdown in some subtle ways
 
@@ -95,6 +97,25 @@ defaults:
     values:
       sidebar: "marketplace_user_sidebar"
       product-type: 'marketplace/user'
+      role: "user"
+  -
+    scope:
+      path: "docs/scos"
+    values:
+      product: "scos"
+  -
+    scope:
+      path: "docs/scos/dev"
+    values:
+      sidebar: "scos_dev_sidebar"
+      product-type: 'scos/dev'
+      role: "dev"
+  -
+    scope:
+      path: "docs/scos/user"
+    values:
+      sidebar: "scos_user_sidebar"
+      product-type: 'scos/user'
       role: "user"
 
 versions:
@@ -154,3 +175,6 @@ sass:
 
 last-modified-at:
   date-format: '%Y%m%dT%H%M'
+
+redirect_from:
+  json: false

--- a/_config_production.yml
+++ b/_config_production.yml
@@ -1,0 +1,5 @@
+plugins:
+  - jekyll-feed
+  - jekyll-last-modified-at
+  - jekyll-include-cache
+  - jekyll-redirect-from

--- a/_data/sidebars/scos_dev_sidebar.yml
+++ b/_data/sidebars/scos_dev_sidebar.yml
@@ -1,0 +1,12630 @@
+title: SCOS Developer Guides
+entries:
+  - product: SCOS
+    nested:
+    - title: Developer guides
+      nested:
+        - title: Developer Getting Started Guide
+          url: /docs/scos/dev/developer-guides/dev-getting-sta.html
+          include_versions:
+            - '201907.0'
+            - '202001.0'
+            - '202005.0'
+        - title: Updating a Spryker-Based Project
+          url: /docs/scos/dev/developer-guides/updating-a-spry.html
+          include_versions:
+            - '202001.0'
+            - '202005.0'
+        - title: Installation
+          nested:
+            - title: About the Installation Guides
+              url: /docs/scos/dev/developer-guides/installation/about-installat.html
+            - title: B2B Demo Shop Installation Guides
+              nested:
+                - title: B2B Demo Shop Installation- Without Development Virtual
+                    Machine
+                  url: /docs/scos/dev/developer-guides/installation/b2b-demo-shop-installation-guides/b2b-demo-shop-i.html
+                  include_versions:
+                    - '202001.0'
+                - title: B2B Demo Shop Installation- Mac OS or Linux, with
+                    Development Virtual Machine
+                  url: /docs/scos/dev/developer-guides/installation/b2b-demo-shop-installation-guides/installation-gu.html
+                  include_versions:
+                    - '202001.0'
+            - title: Debugging
+              nested:
+                - title: Debugging Setup
+                  url: /docs/scos/dev/developer-guides/installation/debugging/debugging-setup.html
+                  include_versions:
+                    - '201811.0'
+                    - '201903.0'
+                    - '201907.0'
+                    - '202001.0'
+            - title: Post-Installation Steps and Additional Info
+              url: /docs/scos/dev/developer-guides/installation/post-installati.html
+              include_versions:
+                - '201903.0'
+            - title: B2C Demo Shop Installation Guides
+              nested:
+                - title: B2C Demo Shop Installation- Mac OS or Linux, with
+                    Development Virtual Machine
+                  url: /docs/scos/dev/developer-guides/installation/b2c-demo-shop-installation-guides/b2c-demo-shop-i.html
+                  include_versions:
+                    - '202001.0'
+            - title: Installing Spryker with Custom Set of Modules
+              url: /docs/scos/dev/developer-guides/installation/installation-gu.html
+              include_versions:
+                - '201907.0'
+                - '202001.0'
+                - '202005.0'
+                - '202009.0'
+                - '202108.0'
+            - title: Configuring the Database Server
+              url: /docs/scos/dev/developer-guides/installation/configure-datab.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+                - '201907.0'
+                - '202001.0'
+                - '202005.0'
+            - title: Supported Browsers
+              url: /docs/scos/dev/developer-guides/installation/supported-brows.html
+              include_versions:
+                - '202001.0'
+            - title: Spryker in Docker
+              nested:
+                - title: Configuration
+                  nested:
+                    - title: Additional DevOPS Guidelines
+                      url: /docs/scos/dev/developer-guides/installation/spryker-in-docker/configuration/additional-devo.html
+                      include_versions:
+                        - '202001.0'
+                        - '202005.0'
+                    - title: Services
+                      url: /docs/scos/dev/developer-guides/installation/spryker-in-docker/configuration/services.html
+                      include_versions:
+                        - '202001.0'
+                        - '202005.0'
+                    - title: Self-signed SSL Certificate Setup
+                      url: /docs/scos/dev/developer-guides/installation/spryker-in-docker/configuration/self-signed-ssl.html
+                      include_versions:
+                        - '202005.0'
+                - title: Docker SDK
+                  nested:
+                    - title: Docker SDK
+                      url: /docs/scos/dev/developer-guides/installation/spryker-in-docker/docker-sdk/docker-sdk.html
+                      include_versions:
+                        - '201907.0'
+                        - '202001.0'
+                        - '202005.0'
+                    - title: Deploy File Reference - 1.0
+                      url: /docs/scos/dev/developer-guides/installation/spryker-in-docker/docker-sdk/deploy-file-ref.html
+                      include_versions:
+                        - '201907.0'
+                        - '202001.0'
+                        - '202005.0'
+                - title: Debugging Setup in Docker
+                  url: /docs/scos/dev/developer-guides/installation/spryker-in-docker/debugging-setup.html
+                  include_versions:
+                    - '201907.0'
+                    - '202001.0'
+                - title: Docker installation prerequisites
+                  nested:
+                    - title: Docker Installation Prerequisites - Windows
+                      url: /docs/scos/dev/developer-guides/installation/spryker-in-docker/docker-installation-prerequisites/docker-installa.html
+                      include_versions:
+                        - '202001.0'
+                        - '202005.0'
+                - title: Troubleshooting
+                  url: /docs/scos/dev/developer-guides/installation/spryker-in-docker/spryker-in-dock.html
+                  include_versions:
+                    - '202001.0'
+                    - '202005.0'
+                - title: Docker Environment Infrustructure
+                  url: /docs/scos/dev/developer-guides/installation/spryker-in-docker/docker-environm.html
+                  include_versions:
+                    - '202001.0'
+                    - '202005.0'
+                - title: Installation guides
+                  nested:
+                    - title: Integrating Docker into Existing Projects
+                      url: /docs/scos/dev/developer-guides/installation/spryker-in-docker/installation-guides/integrating-doc.html
+                      include_versions:
+                        - '202001.0'
+                        - '202005.0'
+                    - title: Modes Overview
+                      url: /docs/scos/dev/developer-guides/installation/spryker-in-docker/installation-guides/modes-overview.html
+                      include_versions:
+                        - '202001.0'
+                        - '202005.0'
+                    - title: Running Production
+                      url: /docs/scos/dev/developer-guides/installation/spryker-in-docker/installation-guides/running-product.html
+                      include_versions:
+                        - '202001.0'
+                        - '202005.0'
+                    - title: Installation Guide - Demo Mode
+                      url: /docs/scos/dev/developer-guides/installation/spryker-in-docker/installation-guides/installation-gu.html
+                      include_versions:
+                        - '202001.0'
+                        - '202005.0'
+                    - title: Getting Started with Docker Old
+                      url: /docs/scos/dev/developer-guides/installation/spryker-in-docker/installation-guides/getting-started.html
+                      include_versions:
+                        - '202001.0'
+                - title: Getting Started with Docker
+                  url: /docs/scos/dev/developer-guides/installation/spryker-in-docker/getting-started.html
+                  include_versions:
+                    - '201907.0'
+                    - '202001.0'
+                    - '202005.0'
+                - title: Debugger Setup in Docker
+                  url: /docs/scos/dev/developer-guides/installation/spryker-in-docker/debugging-setup.html
+                  include_versions:
+                    - '202005.0'
+                - title: Integrating Docker into an Existing Project
+                  url: /docs/scos/dev/developer-guides/installation/spryker-in-docker/integrating-doc.html
+                  include_versions:
+                    - '201907.0'
+                - title: Docker Install Prerequisites
+                  nested:
+                    - title: Docker Install Prerequisites - MacOS
+                      url: /docs/scos/dev/developer-guides/installation/spryker-in-docker/docker-install-prerequisites/docker-install-.html
+                      include_versions:
+                        - '201907.0'
+                - title: Spryker in Docker
+                  url: /docs/scos/dev/developer-guides/installation/spryker-in-docker/spryker-in-dock.html
+                  include_versions:
+                    - '201907.0'
+                - title: Maintenance
+                  nested:
+                    - title: Additional DevOPS Information
+                      url: /docs/scos/dev/developer-guides/installation/spryker-in-docker/maintenance/additional-devo.html
+                      include_versions:
+                        - '201907.0'
+            - title: Troubleshooting
+              url: /docs/scos/dev/developer-guides/installation/installation-tr.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+                - '201907.0'
+                - '202001.0'
+                - '202005.0'
+            - title: System Requirements
+              url: /docs/scos/dev/developer-guides/installation/system-requirem.html
+              include_versions:
+                - '201903.0'
+            - title: Redis Configuration
+              url: /docs/scos/dev/developer-guides/installation/redis-configrua.html
+            - title: Composer
+              url: /docs/scos/dev/developer-guides/installation/composer.html
+              include_versions:
+                - '201903.0'
+            - title: Virtual Machine Cleanup
+              url: /docs/scos/dev/developer-guides/installation/vm-cleanup.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+                - '201907.0'
+                - '202001.0'
+            - title: About Installation
+              url: /docs/scos/dev/developer-guides/installation/about-installat.html
+              include_versions:
+                - '201811.0'
+            - title: Developer Getting Started Guide
+              url: /docs/scos/dev/developer-guides/installation/dev-getting-sta.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+            - title: B2B Demo Shop Installation Guide
+              url: /docs/scos/dev/developer-guides/installation/installation-gu.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+            - title: Spryker in Vagrant
+              nested:
+                - title: B2B or B2C Demo Shop installation- Mac OS or Linux, with
+                    Development Virtual Machine
+                  url: /docs/scos/dev/developer-guides/installation/spryker-in-vagrant/b2b-b2c-demo-sh.html
+                  include_versions:
+                    - '202005.0'
+                - title: Debugger
+                  nested:
+                    - title: Debugger Setup in Vagrant
+                      url: /docs/scos/dev/developer-guides/installation/spryker-in-vagrant/debugger/debugging-setup.html
+                      include_versions:
+                        - '202005.0'
+                - title: Virtual Machine Cleanup
+                  url: /docs/scos/dev/developer-guides/installation/spryker-in-vagrant/vm-cleanup.html
+                  include_versions:
+                    - '202005.0'
+            - title: Installing Spryker with Docker
+              nested:
+                - title: Configuration
+                  nested:
+                    - title: Setting up a self-signed SSL certificate
+                      url: /docs/scos/dev/developer-guides/installation/installing-spryker-with-docker/configuration/setting-up-a-se.html
+                      include_versions:
+                        - '202009.0'
+                        - '202108.0'
+                    - title: Additional DevOPS guidelines
+                      url: /docs/scos/dev/developer-guides/installation/installing-spryker-with-docker/configuration/additional-devo.html
+                      include_versions:
+                        - '202009.0'
+                        - '202108.0'
+                - title: Docker installation prerequisites
+                  nested:
+                    - title: Installing Docker prerequisites on Linux
+                      url: /docs/scos/dev/developer-guides/installation/installing-spryker-with-docker/docker-installation-prerequisites/installing-dock.html
+                      include_versions:
+                        - '202009.0'
+                        - '202108.0'
+                - title: Installing Spryker with Docker
+                  url: /docs/scos/dev/developer-guides/installation/installing-spryker-with-docker/installing-spry.html
+                  include_versions:
+                    - '202009.0'
+                    - '202108.0'
+                - title: Installation guides
+                  nested:
+                    - title: Choosing an installation mode
+                      url: /docs/scos/dev/developer-guides/installation/installing-spryker-with-docker/installation-guides/choosing-an-ins.html
+                      include_versions:
+                        - '202009.0'
+                        - '202108.0'
+                    - title: Integrating the Docker SDK into existing projects
+                      url: /docs/scos/dev/developer-guides/installation/installing-spryker-with-docker/installation-guides/integrating-the.html
+                      include_versions:
+                        - '202009.0'
+                        - '202108.0'
+                    - title: Running production
+                      url: /docs/scos/dev/developer-guides/installation/installing-spryker-with-docker/installation-guides/running-product.html
+                      include_versions:
+                        - '202009.0'
+                        - '202108.0'
+                    - title: Installing in Demo mode on MacOS and Linux
+                      url: /docs/scos/dev/developer-guides/installation/installing-spryker-with-docker/installation-guides/installing-in-d.html
+                      include_versions:
+                        - '202009.0'
+                        - '202108.0'
+                - title: Database access credentials
+                  url: /docs/scos/dev/developer-guides/installation/installing-spryker-with-docker/database-access.html
+                  include_versions:
+                    - '202009.0'
+                    - '202108.0'
+            - title: Install module structure and configuration
+              url: /docs/scos/dev/developer-guides/installation/install-module-.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+            - title: Installing Spryker with Vagrant
+              nested:
+                - title: B2B or B2C Demo Shop installation- Mac OS or Linux, with
+                    Development Virtual Machine
+                  url: /docs/scos/dev/developer-guides/installation/installing-spryker-with-vagrant/b2b-b2c-demo-sh.html
+                  include_versions:
+                    - '202009.0'
+                    - '202108.0'
+                - title: Upgrading to the latest version of Node.js inside devwm
+                  url: /docs/scos/dev/developer-guides/installation/installing-spryker-with-vagrant/upgrading-to-th.html
+                  include_versions:
+                    - '202009.0'
+                    - '202108.0'
+                - title: Debugger
+                  nested:
+                    - title: Configuring debugging in Vagrant with VM below version
+                        91
+                      url: /docs/scos/dev/developer-guides/installation/installing-spryker-with-vagrant/debugger/configuring-deb.html
+                      include_versions:
+                        - '202009.0'
+                        - '202108.0'
+                - title: Virtual Machine Cleanup
+                  url: /docs/scos/dev/developer-guides/installation/installing-spryker-with-vagrant/vm-cleanup.html
+                  include_versions:
+                    - '202009.0'
+                    - '202108.0'
+            - title: Configuring the database server
+              url: /docs/scos/dev/developer-guides/installation/configure-datab.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+            - title: B2C Demo Shop Installation Guide
+              url: /docs/scos/dev/developer-guides/installation/b2c-demo-shop-i.html
+              include_versions:
+                - '201903.0'
+                - '201907.0'
+        - title: Development guide
+          nested:
+            - title: Session Management
+              url: /docs/scos/dev/developer-guides/development-guide/session-managem.html
+              include_versions:
+                - '201903.0'
+            - title: Guidelines
+              nested:
+                - title: Coding guidelines
+                  nested:
+                    - title: Code Quality
+                      url: /docs/scos/dev/developer-guides/development-guide/guidelines/coding-guidelines/code-quality.html
+                      include_versions:
+                        - '201903.0'
+                    - title: Code Style Guide
+                      url: /docs/scos/dev/developer-guides/development-guide/guidelines/coding-guidelines/code-style-guid.html
+                      include_versions:
+                        - '201811.0'
+                        - '201903.0'
+                        - '201907.0'
+                        - '202001.0'
+                        - '202005.0'
+                    - title: Secure Coding Practices
+                      url: /docs/scos/dev/developer-guides/development-guide/guidelines/coding-guidelines/secure-coding-p.html
+                      include_versions:
+                        - '201903.0'
+                    - title: Code Architecture Guide
+                      url: /docs/scos/dev/developer-guides/development-guide/guidelines/coding-guidelines/code-architectu.html
+                      include_versions:
+                        - '201903.0'
+                    - title: Code style guide
+                      url: /docs/scos/dev/developer-guides/development-guide/guidelines/coding-guidelines/code-style-guid.html
+                      include_versions:
+                        - '202009.0'
+                        - '202108.0'
+                - title: Testing Concepts
+                  url: /docs/scos/dev/developer-guides/development-guide/guidelines/testing-concept.html
+                  include_versions:
+                    - '201903.0'
+                - title: Making Your Spryker Shop Secure
+                  url: /docs/scos/dev/developer-guides/development-guide/guidelines/making-your-spr.html
+                  include_versions:
+                    - '202001.0'
+                    - '202005.0'
+                    - '202009.0'
+                    - '202108.0'
+                - title: Module Configuration Convention
+                  url: /docs/scos/dev/developer-guides/development-guide/guidelines/module-configur.html
+                  include_versions:
+                    - '201903.0'
+                - title: Guidelines for New GDPR Rules
+                  url: /docs/scos/dev/developer-guides/development-guide/guidelines/guidelines-for-.html
+                  include_versions:
+                    - '201811.0'
+                    - '201903.0'
+                    - '201907.0'
+                    - '202001.0'
+                    - '202005.0'
+                - title: Performance Guidelines
+                  url: /docs/scos/dev/developer-guides/development-guide/guidelines/performance-gui.html
+                  include_versions:
+                    - '201811.0'
+                    - '201903.0'
+                    - '201907.0'
+                    - '202001.0'
+                    - '202005.0'
+                - title: Data Processing Guidelines
+                  url: /docs/scos/dev/developer-guides/development-guide/guidelines/data-processing.html
+                  include_versions:
+                    - '202005.0'
+                    - '202009.0'
+                    - '202108.0'
+                - title: Project Development Guidelines
+                  url: /docs/scos/dev/developer-guides/development-guide/guidelines/project-develop.html
+                  include_versions:
+                    - '202005.0'
+                    - '202009.0'
+                    - '202108.0'
+                - title: Testing concepts
+                  nested:
+                    - title: Data builder
+                      url: /docs/scos/dev/developer-guides/development-guide/guidelines/testing-concepts/data-builder.html
+                      include_versions:
+                        - '202005.0'
+                    - title: Test helper
+                      url: /docs/scos/dev/developer-guides/development-guide/guidelines/testing-concepts/test-helper.html
+                      include_versions:
+                        - '202005.0'
+                    - title: Best practices
+                      url: /docs/scos/dev/developer-guides/development-guide/guidelines/testing-concepts/best-practices.html
+                      include_versions:
+                        - '202005.0'
+                    - title: Troubleshooting
+                      url: /docs/scos/dev/developer-guides/development-guide/guidelines/testing-concepts/troubleshooting.html
+                      include_versions:
+                        - '202005.0'
+                    - title: Testify
+                      url: /docs/scos/dev/developer-guides/development-guide/guidelines/testing-concepts/testify.html
+                      include_versions:
+                        - '202005.0'
+                    - title: Executing tests
+                      url: /docs/scos/dev/developer-guides/development-guide/guidelines/testing-concepts/executing-tests.html
+                      include_versions:
+                        - '202005.0'
+                    - title: Setup tests
+                      url: /docs/scos/dev/developer-guides/development-guide/guidelines/testing-concepts/setup-tests.html
+                      include_versions:
+                        - '202005.0'
+                    - title: Test framework
+                      url: /docs/scos/dev/developer-guides/development-guide/guidelines/testing-concepts/test-framework.html
+                      include_versions:
+                        - '202005.0'
+                    - title: Codecoverage
+                      url: /docs/scos/dev/developer-guides/development-guide/guidelines/testing-concepts/codecoverage.html
+                      include_versions:
+                        - '202005.0'
+                - title: Testing
+                  nested:
+                    - title: Publish and Synchronization testing
+                      url: /docs/scos/dev/developer-guides/development-guide/guidelines/testing/publish-and-syn.html
+                      include_versions:
+                        - '202009.0'
+                        - '202108.0'
+                    - title: Available test helpers
+                      url: /docs/scos/dev/developer-guides/development-guide/guidelines/testing/available-test-.html
+                      include_versions:
+                        - '202009.0'
+                        - '202108.0'
+                    - title: Setting up Tests
+                      url: /docs/scos/dev/developer-guides/development-guide/guidelines/testing/setting-up-test.html
+                      include_versions:
+                        - '202009.0'
+                        - '202108.0'
+                    - title: Test Helpers
+                      url: /docs/scos/dev/developer-guides/development-guide/guidelines/testing/test-helpers.html
+                      include_versions:
+                        - '202009.0'
+                        - '202108.0'
+                    - title: Testify
+                      url: /docs/scos/dev/developer-guides/development-guide/guidelines/testing/testify.html
+                      include_versions:
+                        - '202009.0'
+                        - '202108.0'
+                    - title: Executing Tests
+                      url: /docs/scos/dev/developer-guides/development-guide/guidelines/testing/executing-tests.html
+                      include_versions:
+                        - '202009.0'
+                        - '202108.0'
+                    - title: Testing Best Practices
+                      url: /docs/scos/dev/developer-guides/development-guide/guidelines/testing/testing-best-pr.html
+                      include_versions:
+                        - '202009.0'
+                        - '202108.0'
+                    - title: Test framework
+                      url: /docs/scos/dev/developer-guides/development-guide/guidelines/testing/test-framework.html
+                      include_versions:
+                        - '202108.0'
+                    - title: Code Coverage
+                      url: /docs/scos/dev/developer-guides/development-guide/guidelines/testing/code-coverage.html
+                      include_versions:
+                        - '202009.0'
+                        - '202108.0'
+                    - title: Data Builders
+                      url: /docs/scos/dev/developer-guides/development-guide/guidelines/testing/data-builders.html
+                      include_versions:
+                        - '202009.0'
+                        - '202108.0'
+                    - title: Test Framework
+                      url: /docs/scos/dev/developer-guides/development-guide/guidelines/testing/test-framework.html
+                      include_versions:
+                        - '202009.0'
+                - title: Front-end performance guidelines
+                  url: /docs/scos/dev/developer-guides/development-guide/guidelines/front-end-perfo.html
+                  include_versions:
+                    - '202009.0'
+                    - '202108.0'
+                - title: Performance guidelines
+                  url: /docs/scos/dev/developer-guides/development-guide/guidelines/performance-gui.html
+                  include_versions:
+                    - '202009.0'
+                    - '202108.0'
+            - title: Front-End
+              nested:
+                - title: Zed
+                  nested:
+                    - title: Custom Twig Functions for Zed
+                      url: /docs/scos/dev/developer-guides/development-guide/front-end/zed/custom-twig-fun.html
+                      include_versions:
+                        - '202001.0'
+                        - '202005.0'
+                        - '202009.0'
+                        - '202108.0'
+                    - title: Oryx Builder Overview and Setup
+                      url: /docs/scos/dev/developer-guides/development-guide/front-end/zed/oryx.html
+                      include_versions:
+                        - '201903.0'
+                    - title: Oryx for Zed
+                      url: /docs/scos/dev/developer-guides/development-guide/front-end/zed/oryx-for-zed.html
+                      include_versions:
+                        - '201903.0'
+                    - title: 'Overriding Webpack, JS, SCSS for ZED on project level'
+                      url: /docs/scos/dev/developer-guides/development-guide/front-end/zed/overriding-webp.html
+                      include_versions:
+                        - '202108.0'
+                - title: Yves
+                  nested:
+                    - title: Custom Twig Functions for Yves
+                      url: /docs/scos/dev/developer-guides/development-guide/front-end/yves/custom-twig-fun.html
+                      include_versions:
+                        - '202001.0'
+                        - '202005.0'
+                        - '202009.0'
+                        - '202108.0'
+                    - title: Adding and Using External Libraries in Yves
+                      url: /docs/scos/dev/developer-guides/development-guide/front-end/yves/adding-using-ex.html
+                      include_versions:
+                        - '201903.0'
+                    - title: Atomic frontend
+                      nested:
+                        - title: Atomic Frontend- General Overview
+                          url: /docs/scos/dev/developer-guides/development-guide/front-end/yves/atomic-frontend/atomic-front-en.html
+                          include_versions:
+                            - '201811.0'
+                            - '201903.0'
+                            - '201907.0'
+                            - '202001.0'
+                            - '202005.0'
+                        - title: Integrating JQuery into Atomic Frontend
+                          url: /docs/scos/dev/developer-guides/development-guide/front-end/yves/atomic-frontend/t-integrate-jqu.html
+                          include_versions:
+                            - '201903.0'
+                        - title: Managing the components
+                          nested:
+                            - title: Creating a Component
+                              url: /docs/scos/dev/developer-guides/development-guide/front-end/yves/atomic-frontend/managing-the-components/t-create-compon.html
+                            - title: Using a Component
+                              url: /docs/scos/dev/developer-guides/development-guide/front-end/yves/atomic-frontend/managing-the-components/t-use-component.html
+                            - title: Extending a Component
+                              url: /docs/scos/dev/developer-guides/development-guide/front-end/yves/atomic-frontend/managing-the-components/t-extend-compon.html
+                            - title: Overriding a Component
+                              url: /docs/scos/dev/developer-guides/development-guide/front-end/yves/atomic-frontend/managing-the-components/t-override-comp.html
+                              include_versions:
+                                - '201903.0'
+                            - title: Tutorial - Frontend - Create a Component
+                              url: /docs/scos/dev/developer-guides/development-guide/front-end/yves/atomic-frontend/managing-the-components/t-create-compon.html
+                              include_versions:
+                                - '201811.0'
+                            - title: Tutorial - Frontend - Use a Component
+                              url: /docs/scos/dev/developer-guides/development-guide/front-end/yves/atomic-frontend/managing-the-components/t-use-component.html
+                              include_versions:
+                                - '201811.0'
+                            - title: Tutorial - Frontend - Extend a Component
+                              url: /docs/scos/dev/developer-guides/development-guide/front-end/yves/atomic-frontend/managing-the-components/t-extend-compon.html
+                              include_versions:
+                                - '201811.0'
+                        - title: Customizing Spryker front end
+                          url: /docs/scos/dev/developer-guides/development-guide/front-end/yves/atomic-frontend/customizing-spr.html
+                          include_versions:
+                            - '202001.0'
+                            - '202009.0'
+                            - '202108.0'
+                        - title: Integrating React into Atomic Frontend
+                          url: /docs/scos/dev/developer-guides/development-guide/front-end/yves/atomic-frontend/integrating-rea.html
+                          include_versions:
+                            - '201907.0'
+                            - '202001.0'
+                            - '202005.0'
+                            - '202009.0'
+                            - '202108.0'
+                        - title: Tutorial - Customize Spryker Frontend
+                          url: /docs/scos/dev/developer-guides/development-guide/front-end/yves/atomic-frontend/t-customize-spr.html
+                          include_versions:
+                            - '201811.0'
+                            - '201903.0'
+                            - '201907.0'
+                            - '202005.0'
+                        - title: Atomic Front End- general overview
+                          url: /docs/scos/dev/developer-guides/development-guide/front-end/yves/atomic-frontend/atomic-front-en.html
+                          include_versions:
+                            - '202009.0'
+                            - '202108.0'
+                        - title: Сustomization example - B2B Product Details page
+                          url: /docs/scos/dev/developer-guides/development-guide/front-end/yves/atomic-frontend/customization-e.html
+                          include_versions:
+                            - '202009.0'
+                            - '202108.0'
+                    - title: Frontend assets building and loading
+                      url: /docs/scos/dev/developer-guides/development-guide/front-end/yves/frontend-assets.html
+                      include_versions:
+                        - '202009.0'
+                        - '202108.0'
+                    - title: Yves multi-themes
+                      url: /docs/scos/dev/developer-guides/development-guide/front-end/yves/yves-multi-them.html
+                      include_versions:
+                        - '202009.0'
+                        - '202108.0'
+                    - title: Front-end builder for Yves
+                      url: /docs/scos/dev/developer-guides/development-guide/front-end/yves/front-end-build.html
+                      include_versions:
+                        - '202009.0'
+                        - '202108.0'
+                - title: Front-end builder for Yves
+                  url: /docs/scos/dev/developer-guides/development-guide/front-end/front-end-build.html
+                  include_versions:
+                    - '202001.0'
+                - title: Legacy Demoshop
+                  nested:
+                    - title: Development
+                      url: /docs/scos/dev/developer-guides/development-guide/front-end/legacy-demoshop/development-for.html
+                      include_versions:
+                        - '201903.0'
+                    - title: Twig templates
+                      nested:
+                        - title: Overview - Twig
+                          url: /docs/scos/dev/developer-guides/development-guide/front-end/legacy-demoshop/twig-templates/twig-overview.html
+                          include_versions:
+                            - '201903.0'
+                        - title: Best Practices - Twig Templates
+                          url: /docs/scos/dev/developer-guides/development-guide/front-end/legacy-demoshop/twig-templates/twig-best-pract.html
+                          include_versions:
+                            - '201903.0'
+                    - title: Build and Optimization
+                      url: /docs/scos/dev/developer-guides/development-guide/front-end/legacy-demoshop/build-optimizat.html
+                      include_versions:
+                        - '201903.0'
+                    - title: Download and Structure
+                      url: /docs/scos/dev/developer-guides/development-guide/front-end/legacy-demoshop/download-struct.html
+                      include_versions:
+                        - '201903.0'
+                    - title: Demoshop Guide
+                      url: /docs/scos/dev/developer-guides/development-guide/front-end/legacy-demoshop/demoshop-guide.html
+                      include_versions:
+                        - '201903.0'
+                    - title: About the Legacy Demoshop Front-end Guides
+                      url: /docs/scos/dev/developer-guides/development-guide/front-end/legacy-demoshop/about-legacy-de.html
+                      include_versions:
+                        - '201903.0'
+                    - title: Public Folder
+                      url: /docs/scos/dev/developer-guides/development-guide/front-end/legacy-demoshop/public-folder.html
+                      include_versions:
+                        - '201903.0'
+                    - title: Frontend Overview
+                      url: /docs/scos/dev/developer-guides/development-guide/front-end/legacy-demoshop/frontend-overvi.html
+                      include_versions:
+                        - '201903.0'
+                - title: Miscellaneous Guides
+                  nested:
+                    - title: User Interface Guide
+                      url: /docs/scos/dev/developer-guides/development-guide/front-end/miscellaneous-guides/user-interface-.html
+                      include_versions:
+                        - '201811.0'
+                        - '202005.0'
+                - title: Frontend Builder for Yves
+                  url: /docs/scos/dev/developer-guides/development-guide/front-end/frontend-builde.html
+                  include_versions:
+                    - '201907.0'
+                    - '202005.0'
+            - title: Best practices
+              nested:
+                - title: Coding Best Practices
+                  url: /docs/scos/dev/developer-guides/development-guide/best-practices/coding-best-pra.html
+                  include_versions:
+                    - '201903.0'
+                - title: Search best practices
+                  nested:
+                    - title: Full-Text Search
+                      url: /docs/scos/dev/developer-guides/development-guide/best-practices/search-best-practices/full-text-searc.html
+                      include_versions:
+                        - '201903.0'
+                    - title: Personalization- Dynamic Pricing
+                      url: /docs/scos/dev/developer-guides/development-guide/best-practices/search-best-practices/personalization.html
+                      include_versions:
+                        - '201903.0'
+                    - title: Generic Faceted Search
+                      url: /docs/scos/dev/developer-guides/development-guide/best-practices/search-best-practices/generic-faceted.html
+                      include_versions:
+                        - '201903.0'
+                    - title: Simple Spelling Suggestions
+                      url: /docs/scos/dev/developer-guides/development-guide/best-practices/search-best-practices/simple-spelling.html
+                      include_versions:
+                        - '201903.0'
+                    - title: Multi-Term Auto Completion
+                      url: /docs/scos/dev/developer-guides/development-guide/best-practices/search-best-practices/multi-term-auto.html
+                      include_versions:
+                        - '201903.0'
+                    - title: Naive Product Centric Approach
+                      url: /docs/scos/dev/developer-guides/development-guide/best-practices/search-best-practices/naive-product-c.html
+                      include_versions:
+                        - '201903.0'
+                    - title: Data-Driven Ranking
+                      url: /docs/scos/dev/developer-guides/development-guide/best-practices/search-best-practices/data-driven-ran.html
+                      include_versions:
+                        - '201903.0'
+                    - title: Usage-Driven Schema & Document Structure
+                      url: /docs/scos/dev/developer-guides/development-guide/best-practices/search-best-practices/usage-driven-sc.html
+                      include_versions:
+                        - '201903.0'
+                    - title: Other Best Practices
+                      url: /docs/scos/dev/developer-guides/development-guide/best-practices/search-best-practices/other-best-prac.html
+                      include_versions:
+                        - '201903.0'
+                    - title: On-Site Search
+                      url: /docs/scos/dev/developer-guides/development-guide/best-practices/search-best-practices/search-design-p.html
+                      include_versions:
+                        - '201903.0'
+                    - title: Precise search by super attributes
+                      url: /docs/scos/dev/developer-guides/development-guide/best-practices/search-best-practices/precise-search-.html
+                      include_versions:
+                        - '202009.0'
+                        - '202108.0'
+                - title: State machine cookbook
+                  nested:
+                    - title: State Machine Cookbook - Part 2 - Building a State
+                        Machine
+                      url: /docs/scos/dev/developer-guides/development-guide/best-practices/state-machine-cookbook/state-machine-c.html
+                      include_versions:
+                        - '201811.0'
+                        - '201903.0'
+                        - '201907.0'
+                        - '202001.0'
+                        - '202005.0'
+                    - title: State machine cookbook - part 2 - building a state
+                        machine
+                      url: /docs/scos/dev/developer-guides/development-guide/best-practices/state-machine-cookbook/state-machine-c.html
+                      include_versions:
+                        - '202009.0'
+                        - '202108.0'
+                - title: Basic SEO techniques to use in your project
+                  url: /docs/scos/dev/developer-guides/development-guide/best-practices/basic-seo-techn.html
+                  include_versions:
+                    - '202009.0'
+                    - '202108.0'
+            - title: Back-End
+              nested:
+                - title: Zed
+                  nested:
+                    - title: Business Layer
+                      nested:
+                        - title: About the Business Layer
+                          url: /docs/scos/dev/developer-guides/development-guide/back-end/zed/business-layer/business-layer.html
+                          include_versions:
+                            - '201903.0'
+                        - title: Facade
+                          nested:
+                            - title: Implementing a Facade
+                              url: /docs/scos/dev/developer-guides/development-guide/back-end/zed/business-layer/facade/implementing-fa.html
+                            - title: Using a Facade
+                              url: /docs/scos/dev/developer-guides/development-guide/back-end/zed/business-layer/facade/using-facade.html
+                              include_versions:
+                                - '201903.0'
+                            - title: Design by Contract (DBC) - Facade
+                              url: /docs/scos/dev/developer-guides/development-guide/back-end/zed/business-layer/facade/zed-facade-desi.html
+                              include_versions:
+                                - '201903.0'
+                            - title: About Facade
+                              url: /docs/scos/dev/developer-guides/development-guide/back-end/zed/business-layer/facade/facade.html
+                              include_versions:
+                                - '201903.0'
+                        - title: Custom Exceptions
+                          url: /docs/scos/dev/developer-guides/development-guide/back-end/zed/business-layer/custom-exceptio.html
+                          include_versions:
+                            - '201903.0'
+                        - title: Business Models
+                          url: /docs/scos/dev/developer-guides/development-guide/back-end/zed/business-layer/business-models.html
+                          include_versions:
+                            - '201903.0'
+                    - title: Communication Layer
+                      nested:
+                        - title: Adding Indexes to Foreign Key Columns- Index
+                            Generator
+                          url: /docs/scos/dev/developer-guides/development-guide/back-end/zed/communication-layer/postgres-index-.html
+                          include_versions:
+                            - '201811.0'
+                            - '201903.0'
+                            - '201907.0'
+                            - '202001.0'
+                            - '202005.0'
+                        - title: Controllers and Actions
+                          url: /docs/scos/dev/developer-guides/development-guide/back-end/zed/communication-layer/zed-controllers.html
+                          include_versions:
+                            - '201903.0'
+                        - title: Adding indexes to foreign key columns- index
+                            generator
+                          url: /docs/scos/dev/developer-guides/development-guide/back-end/zed/communication-layer/postgres-index-.html
+                          include_versions:
+                            - '202009.0'
+                            - '202108.0'
+                    - title: Persistence Layer
+                      nested:
+                        - title: Entity
+                          url: /docs/scos/dev/developer-guides/development-guide/back-end/zed/persistence-layer/entity.html
+                          include_versions:
+                            - '201903.0'
+                        - title: Query Container
+                          nested:
+                            - title: About the Query Container
+                              url: /docs/scos/dev/developer-guides/development-guide/back-end/zed/persistence-layer/query-container/query-container.html
+                              include_versions:
+                                - '201903.0'
+                            - title: Using a Query Container
+                              url: /docs/scos/dev/developer-guides/development-guide/back-end/zed/persistence-layer/query-container/using-a-query-c.html
+                              include_versions:
+                                - '201903.0'
+                            - title: Implementing a Query Container
+                              url: /docs/scos/dev/developer-guides/development-guide/back-end/zed/persistence-layer/query-container/implementing-a-.html
+                              include_versions:
+                                - '201903.0'
+                        - title: Entity Manager
+                          url: /docs/scos/dev/developer-guides/development-guide/back-end/zed/persistence-layer/entity-manager.html
+                          include_versions:
+                            - '201903.0'
+                        - title: Back-End Zed
+                          url: /docs/scos/dev/developer-guides/development-guide/back-end/zed/persistence-layer/zed.html
+                          include_versions:
+                            - '202001.0'
+                            - '202005.0'
+                            - '202009.0'
+                            - '202108.0'
+                        - title: About the Persistence Layer
+                          url: /docs/scos/dev/developer-guides/development-guide/back-end/zed/persistence-layer/persistence-lay.html
+                          include_versions:
+                            - '201903.0'
+                        - title: Database Schema Definition
+                          url: /docs/scos/dev/developer-guides/development-guide/back-end/zed/persistence-layer/database-schema.html
+                          include_versions:
+                            - '201811.0'
+                            - '201903.0'
+                            - '201907.0'
+                            - '202001.0'
+                            - '202005.0'
+                        - title: Repository
+                          url: /docs/scos/dev/developer-guides/development-guide/back-end/zed/persistence-layer/repository.html
+                          include_versions:
+                            - '201903.0'
+                        - title: Query Objects- Creation and Usage
+                          url: /docs/scos/dev/developer-guides/development-guide/back-end/zed/persistence-layer/query-objects.html
+                          include_versions:
+                            - '201903.0'
+                        - title: Database Overview
+                          url: /docs/scos/dev/developer-guides/development-guide/back-end/zed/persistence-layer/database-overvi.html
+                          include_versions:
+                            - '201903.0'
+                        - title: Database schema definition
+                          url: /docs/scos/dev/developer-guides/development-guide/back-end/zed/persistence-layer/database-schema.html
+                          include_versions:
+                            - '202009.0'
+                            - '202108.0'
+                    - title: About Zed
+                      url: /docs/scos/dev/developer-guides/development-guide/back-end/zed/about-zed.html
+                      include_versions:
+                        - '201811.0'
+                        - '201903.0'
+                        - '201907.0'
+                        - '202001.0'
+                        - '202005.0'
+                    - title: Back-End Zed
+                      url: /docs/scos/dev/developer-guides/development-guide/back-end/zed/zed.html
+                      include_versions:
+                        - '201811.0'
+                        - '201903.0'
+                        - '201907.0'
+                    - title: Zed overview
+                      url: /docs/scos/dev/developer-guides/development-guide/back-end/zed/zed-overview.html
+                      include_versions:
+                        - '202009.0'
+                        - '202108.0'
+                - title: Yves
+                  nested:
+                    - title: Controllers and Actions
+                      url: /docs/scos/dev/developer-guides/development-guide/back-end/yves/yves-controller.html
+                      include_versions:
+                        - '201903.0'
+                    - title: Modular Frontend
+                      url: /docs/scos/dev/developer-guides/development-guide/back-end/yves/modular-fronten.html
+                      include_versions:
+                        - '201903.0'
+                    - title: Adding translations for Yves
+                      url: /docs/scos/dev/developer-guides/development-guide/back-end/yves/frontend-transl.html
+                      include_versions:
+                        - '201903.0'
+                    - title: Yves Routes
+                      url: /docs/scos/dev/developer-guides/development-guide/back-end/yves/t-yves-routes.html
+                      include_versions:
+                        - '201903.0'
+                    - title: Front-End Yves
+                      url: /docs/scos/dev/developer-guides/development-guide/back-end/yves/yves.html
+                      include_versions:
+                        - '201903.0'
+                    - title: Client
+                      nested:
+                        - title: Using and Configuring Redis as a Key-value Storage
+                          url: /docs/scos/dev/developer-guides/development-guide/back-end/yves/client/redis-as-kv.html
+                          include_versions:
+                            - '201811.0'
+                            - '201903.0'
+                            - '201907.0'
+                            - '202001.0'
+                        - title: Implementing a Client
+                          url: /docs/scos/dev/developer-guides/development-guide/back-end/yves/client/implementing-a-.html
+                          include_versions:
+                            - '201811.0'
+                            - '201903.0'
+                            - '201907.0'
+                            - '202001.0'
+                        - title: Client
+                          url: /docs/scos/dev/developer-guides/development-guide/back-end/yves/client/client.html
+                          include_versions:
+                            - '201811.0'
+                            - '201903.0'
+                            - '201907.0'
+                            - '202001.0'
+                    - title: Implementing URL Routing in Yves
+                      url: /docs/scos/dev/developer-guides/development-guide/back-end/yves/yves-url-routin.html
+                      include_versions:
+                        - '201903.0'
+                    - title: About Yves
+                      url: /docs/scos/dev/developer-guides/development-guide/back-end/yves/about-yves.html
+                      include_versions:
+                        - '201811.0'
+                        - '201903.0'
+                        - '201907.0'
+                        - '202001.0'
+                        - '202005.0'
+                    - title: Yves Bootstrapping
+                      url: /docs/scos/dev/developer-guides/development-guide/back-end/yves/t-yves-bootstra.html
+                      include_versions:
+                        - '201903.0'
+                    - title: URL
+                      url: /docs/scos/dev/developer-guides/development-guide/back-end/yves/url.html
+                      include_versions:
+                        - '202009.0'
+                        - '202108.0'
+                    - title: CLI Entry Point for Yves
+                      url: /docs/scos/dev/developer-guides/development-guide/back-end/yves/cli-entry-point.html
+                      include_versions:
+                        - '202009.0'
+                        - '202108.0'
+                    - title: Yves overview
+                      url: /docs/scos/dev/developer-guides/development-guide/back-end/yves/yves-overview.html
+                      include_versions:
+                        - '202009.0'
+                        - '202108.0'
+                - title: Running Production
+                  url: /docs/scos/dev/developer-guides/development-guide/back-end/running-product.html
+                  include_versions:
+                    - '201811.0'
+                    - '201903.0'
+                    - '201907.0'
+                    - '202001.0'
+                    - '202005.0'
+                - title: Data manipulation
+                  nested:
+                    - title: Data Publishing
+                      nested:
+                        - title: Publish and Synchronization
+                          url: /docs/scos/dev/developer-guides/development-guide/back-end/data-manipulation/data-publishing/publish-and-syn.html
+                          include_versions:
+                            - '201903.0'
+                        - title: Publish and Synchronize and Multi-Store Shop Systems
+                          url: /docs/scos/dev/developer-guides/development-guide/back-end/data-manipulation/data-publishing/p-s-and-multi-s.html
+                          include_versions:
+                            - '201903.0'
+                        - title: Debugging Listeners
+                          url: /docs/scos/dev/developer-guides/development-guide/back-end/data-manipulation/data-publishing/ht-debug-listen.html
+                        - title: Queue
+                          nested:
+                            - title: Queue Pool
+                              url: /docs/scos/dev/developer-guides/development-guide/back-end/data-manipulation/data-publishing/queue/queue-pool.html
+                              include_versions:
+                                - '201811.0'
+                                - '201903.0'
+                                - '201907.0'
+                            - title: Queue
+                              url: /docs/scos/dev/developer-guides/development-guide/back-end/data-manipulation/data-publishing/queue/queue.html
+                              include_versions:
+                                - '201811.0'
+                                - '201903.0'
+                                - '201907.0'
+                            - title: Integrating RabbitMQ Headers in Queue Messages
+                              url: /docs/scos/dev/developer-guides/development-guide/back-end/data-manipulation/data-publishing/queue/rabbitmq-header.html
+                              include_versions:
+                                - '201903.0'
+                                - '201907.0'
+                        - title: Event
+                          nested:
+                            - title: Configuring an Events Queue
+                              url: /docs/scos/dev/developer-guides/development-guide/back-end/data-manipulation/data-publishing/event/event-configure.html
+                              include_versions:
+                                - '201811.0'
+                                - '201903.0'
+                                - '201907.0'
+                            - title: Event
+                              url: /docs/scos/dev/developer-guides/development-guide/back-end/data-manipulation/data-publishing/event/event.html
+                              include_versions:
+                                - '201811.0'
+                                - '201903.0'
+                                - '201907.0'
+                            - title: Listening to Events
+                              url: /docs/scos/dev/developer-guides/development-guide/back-end/data-manipulation/data-publishing/event/event-listen.html
+                              include_versions:
+                                - '201811.0'
+                                - '201903.0'
+                                - '201907.0'
+                            - title: Adding Events
+                              url: /docs/scos/dev/developer-guides/development-guide/back-end/data-manipulation/data-publishing/event/event-adding.html
+                              include_versions:
+                                - '201811.0'
+                                - '201903.0'
+                                - '201907.0'
+                        - title: Implementing event trigger publisher plugins
+                          url: /docs/scos/dev/developer-guides/development-guide/back-end/data-manipulation/data-publishing/howto-implement.html
+                          include_versions:
+                            - '202009.0'
+                            - '202108.0'
+                        - title: Implementing synchronization plugins
+                          url: /docs/scos/dev/developer-guides/development-guide/back-end/data-manipulation/data-publishing/implementing-sy.html
+                          include_versions:
+                            - '202009.0'
+                            - '202108.0'
+                        - title: Handling data with Publish and Synchronization
+                          url: /docs/scos/dev/developer-guides/development-guide/back-end/data-manipulation/data-publishing/handling-data-w.html
+                          include_versions:
+                            - '202009.0'
+                            - '202108.0'
+                        - title: Synchronization behavior- enabling multiple mappings
+                          url: /docs/scos/dev/developer-guides/development-guide/back-end/data-manipulation/data-publishing/synchronization.html
+                          include_versions:
+                            - '202009.0'
+                            - '202108.0'
+                        - title: Adding publish events
+                          url: /docs/scos/dev/developer-guides/development-guide/back-end/data-manipulation/data-publishing/adding-publish-.html
+                          include_versions:
+                            - '202009.0'
+                            - '202108.0'
+                    - title: Running and Reverting a Database Migration
+                      url: /docs/scos/dev/developer-guides/development-guide/back-end/data-manipulation/running-reverti.html
+                      include_versions:
+                        - '201903.0'
+                    - title: Configuration Management
+                      url: /docs/scos/dev/developer-guides/development-guide/back-end/data-manipulation/configuration-m.html
+                      include_versions:
+                        - '201811.0'
+                        - '201903.0'
+                        - '201907.0'
+                        - '202001.0'
+                        - '202005.0'
+                    - title: DataPayload Conversion
+                      nested:
+                        - title: State machine
+                          nested:
+                            - title: State Machine Console Commands
+                              url: /docs/scos/dev/developer-guides/development-guide/back-end/data-manipulation/datapayload-conversion/state-machine/state-machine-c.html
+                              include_versions:
+                                - '201903.0'
+                            - title: Order Process Modelling via State Machines
+                              url: /docs/scos/dev/developer-guides/development-guide/back-end/data-manipulation/datapayload-conversion/state-machine/order-process-m.html
+                              include_versions:
+                                - '201903.0'
+                            - title: Order management system multi-thread
+                              url: /docs/scos/dev/developer-guides/development-guide/back-end/data-manipulation/datapayload-conversion/state-machine/order-managemen.html
+                              include_versions:
+                                - '202009.0'
+                                - '202108.0'
+                        - title: Multi-Language Setup
+                          url: /docs/scos/dev/developer-guides/development-guide/back-end/data-manipulation/datapayload-conversion/multi-language-.html
+                          include_versions:
+                            - '202001.0'
+                            - '202005.0'
+                            - '202009.0'
+                            - '202108.0'
+                        - title: Refund Process Management
+                          url: /docs/scos/dev/developer-guides/development-guide/back-end/data-manipulation/datapayload-conversion/refund-process-.html
+                          include_versions:
+                            - '202001.0'
+                            - '202005.0'
+                            - '202009.0'
+                            - '202108.0'
+                        - title: Checkout
+                          nested:
+                            - title: Checkout Steps
+                              url: /docs/scos/dev/developer-guides/development-guide/back-end/data-manipulation/datapayload-conversion/checkout/checkout-steps.html
+                              include_versions:
+                                - '202001.0'
+                                - '202005.0'
+                                - '202009.0'
+                                - '202108.0'
+                            - title: Checkout Process Review and Implementation
+                              url: /docs/scos/dev/developer-guides/development-guide/back-end/data-manipulation/datapayload-conversion/checkout/checkout-proces.html
+                        - title: Step Engine
+                          nested:
+                            - title: Step Engine - Use Case Scenario
+                              url: /docs/scos/dev/developer-guides/development-guide/back-end/data-manipulation/datapayload-conversion/step-engine/step-engine-use.html
+                              include_versions:
+                                - '201903.0'
+                            - title: Step Engine Workflow Overview
+                              url: /docs/scos/dev/developer-guides/development-guide/back-end/data-manipulation/datapayload-conversion/step-engine/step-engine-wor.html
+                              include_versions:
+                                - '201903.0'
+                            - title: Step Engine - Creating a Breadcrumb Navigation
+                              url: /docs/scos/dev/developer-guides/development-guide/back-end/data-manipulation/datapayload-conversion/step-engine/step-engine-bre.html
+                              include_versions:
+                                - '201903.0'
+                        - title: Multiple Currencies per Store Configuration
+                          url: /docs/scos/dev/developer-guides/development-guide/back-end/data-manipulation/datapayload-conversion/multiple-curren.html
+                          include_versions:
+                            - '202001.0'
+                            - '202005.0'
+                        - title: Net & Gross Prices Management
+                          url: /docs/scos/dev/developer-guides/development-guide/back-end/data-manipulation/datapayload-conversion/net-gross-price.html
+                          include_versions:
+                            - '202001.0'
+                            - '202005.0'
+                            - '202009.0'
+                            - '202108.0'
+                        - title: Multiple currencies per store configuration
+                          url: /docs/scos/dev/developer-guides/development-guide/back-end/data-manipulation/datapayload-conversion/multiple-curren.html
+                          include_versions:
+                            - '202009.0'
+                            - '202108.0'
+                    - title: Data Interaction
+                      nested:
+                        - title: Transfering Data Between Yves and Zed
+                          url: /docs/scos/dev/developer-guides/development-guide/back-end/data-manipulation/data-interaction/t-transfer-data.html
+                          include_versions:
+                            - '201903.0'
+                            - '201907.0'
+                            - '202001.0'
+                            - '202005.0'
+                        - title: Standard Filters Backend and Frontend Technical
+                            Details
+                          url: /docs/scos/dev/developer-guides/development-guide/back-end/data-manipulation/data-interaction/standard-filter.html
+                          include_versions:
+                            - '202001.0'
+                            - '202005.0'
+                            - '202009.0'
+                            - '202108.0'
+                        - title: Search
+                          nested:
+                            - title: Configuring the Search Features
+                              url: /docs/scos/dev/developer-guides/development-guide/back-end/data-manipulation/data-interaction/search/configuring-the.html
+                              include_versions:
+                                - '201811.0'
+                                - '201903.0'
+                                - '201907.0'
+                                - '202001.0'
+                                - '202005.0'
+                            - title: Configuring Search for Multi-Currency
+                              url: /docs/scos/dev/developer-guides/development-guide/back-end/data-manipulation/data-interaction/search/search-multi-cu.html
+                              include_versions:
+                                - '201903.0'
+                            - title: Configuring Elasticsearch
+                              url: /docs/scos/dev/developer-guides/development-guide/back-end/data-manipulation/data-interaction/search/search-configur.html
+                              include_versions:
+                                - '201903.0'
+                            - title: Configuring the Search Query
+                              url: /docs/scos/dev/developer-guides/development-guide/back-end/data-manipulation/data-interaction/search/configuring-sea.html
+                              include_versions:
+                                - '201811.0'
+                                - '201903.0'
+                                - '201907.0'
+                                - '202001.0'
+                                - '202005.0'
+                            - title: Facet Filter Overview and Configuration
+                              url: /docs/scos/dev/developer-guides/development-guide/back-end/data-manipulation/data-interaction/search/t-working-filte.html
+                              include_versions:
+                                - '201903.0'
+                            - title: Configuring the search features
+                              url: /docs/scos/dev/developer-guides/development-guide/back-end/data-manipulation/data-interaction/search/configuring-the.html
+                              include_versions:
+                                - '202009.0'
+                                - '202108.0'
+                            - title: Configuring the search query
+                              url: /docs/scos/dev/developer-guides/development-guide/back-end/data-manipulation/data-interaction/search/configuring-sea.html
+                              include_versions:
+                                - '202009.0'
+                                - '202108.0'
+                        - title: Defining the Module Dependencies- Dependency
+                            Provider
+                          url: /docs/scos/dev/developer-guides/development-guide/back-end/data-manipulation/data-interaction/dependency-prov.html
+                          include_versions:
+                            - '201903.0'
+                        - title: Tutorial - Transfering Data Between Yves and Zed
+                          url: /docs/scos/dev/developer-guides/development-guide/back-end/data-manipulation/data-interaction/t-transfer-data.html
+                          include_versions:
+                            - '201811.0'
+                        - title: Transfering data between Yves and Zed
+                          url: /docs/scos/dev/developer-guides/development-guide/back-end/data-manipulation/data-interaction/t-transfer-data.html
+                          include_versions:
+                            - '202009.0'
+                            - '202108.0'
+                    - title: Data enrichment
+                      nested:
+                        - title: Session Handlers
+                          url: /docs/scos/dev/developer-guides/development-guide/back-end/data-manipulation/data-enrichment/session-handler.html
+                          include_versions:
+                            - '201903.0'
+                        - title: Implementing and Using Plugins
+                          url: /docs/scos/dev/developer-guides/development-guide/back-end/data-manipulation/data-enrichment/plugin.html
+                          include_versions:
+                            - '201903.0'
+                        - title: Cronjobs
+                          nested:
+                            - title: Cronjob Scheduling
+                              url: /docs/scos/dev/developer-guides/development-guide/back-end/data-manipulation/data-enrichment/cronjobs/cronjob-schedul.html
+                              include_versions:
+                                - '201907.0'
+                                - '202001.0'
+                                - '202005.0'
+                                - '202009.0'
+                                - '202108.0'
+                            - title: Creating a New Custom Scheduler
+                              url: /docs/scos/dev/developer-guides/development-guide/back-end/data-manipulation/data-enrichment/cronjobs/ht-create-a-new.html
+                              include_versions:
+                                - '201907.0'
+                                - '202001.0'
+                                - '202005.0'
+                                - '202009.0'
+                                - '202108.0'
+                            - title: Adding and Configuring a Cronjob
+                              url: /docs/scos/dev/developer-guides/development-guide/back-end/data-manipulation/data-enrichment/cronjobs/adding-and-conf.html
+                        - title: Forms
+                          nested:
+                            - title: Creating Forms
+                              url: /docs/scos/dev/developer-guides/development-guide/back-end/data-manipulation/data-enrichment/forms/t-working-forms.html
+                              include_versions:
+                                - '202001.0'
+                                - '202005.0'
+                                - '202009.0'
+                                - '202108.0'
+                            - title: Form and Validator
+                              url: /docs/scos/dev/developer-guides/development-guide/back-end/data-manipulation/data-enrichment/forms/form-and-valida.html
+                              include_versions:
+                                - '202001.0'
+                                - '202005.0'
+                                - '202009.0'
+                                - '202108.0'
+                        - title: Plugins
+                          nested:
+                            - title: Getting an Overview of the Used Plugins
+                              url: /docs/scos/dev/developer-guides/development-guide/back-end/data-manipulation/data-enrichment/plugins/plugin-overview.html
+                              include_versions:
+                                - '201903.0'
+                        - title: Adding Navigation in Zed
+                          url: /docs/scos/dev/developer-guides/development-guide/back-end/data-manipulation/data-enrichment/adding-navigati.html
+                          include_versions:
+                            - '201811.0'
+                            - '201903.0'
+                            - '201907.0'
+                            - '202001.0'
+                        - title: Console commands
+                          nested:
+                            - title: Getting the List of Console Commands and
+                                Available Options
+                              url: /docs/scos/dev/developer-guides/development-guide/back-end/data-manipulation/data-enrichment/console-commands/getting-the-lis.html
+                              include_versions:
+                                - '201811.0'
+                                - '201903.0'
+                                - '201907.0'
+                                - '202001.0'
+                                - '202005.0'
+                            - title: Implementing a new Console Command
+                              url: /docs/scos/dev/developer-guides/development-guide/back-end/data-manipulation/data-enrichment/console-commands/console-command.html
+                              include_versions:
+                                - '201903.0'
+                            - title: Console Commands in Spryker
+                              url: /docs/scos/dev/developer-guides/development-guide/back-end/data-manipulation/data-enrichment/console-commands/console.html
+                              include_versions:
+                                - '201903.0'
+                            - title: Getting the list of console commands and
+                                available options
+                              url: /docs/scos/dev/developer-guides/development-guide/back-end/data-manipulation/data-enrichment/console-commands/getting-the-lis.html
+                              include_versions:
+                                - '202009.0'
+                                - '202108.0'
+                        - title: Extending Spryker
+                          nested:
+                            - title: Adding a New Module
+                              url: /docs/scos/dev/developer-guides/development-guide/back-end/data-manipulation/data-enrichment/extending-spryker/t-add-new-bundl.html
+                              include_versions:
+                                - '201903.0'
+                            - title: Extending the Spryker-Core Functionality
+                              url: /docs/scos/dev/developer-guides/development-guide/back-end/data-manipulation/data-enrichment/extending-spryker/t-extend-spryke.html
+                              include_versions:
+                                - '201903.0'
+                            - title: Extending a Core Module That is Used by Another
+                              url: /docs/scos/dev/developer-guides/development-guide/back-end/data-manipulation/data-enrichment/extending-spryker/ht-extend-inuse.html
+                              include_versions:
+                                - '201903.0'
+                            - title: Extending the Core
+                              url: /docs/scos/dev/developer-guides/development-guide/back-end/data-manipulation/data-enrichment/extending-spryker/core-extension.html
+                              include_versions:
+                                - '201903.0'
+                        - title: Zed UI tables
+                          nested:
+                            - title: Creating and Configuring Zed Tables
+                              url: /docs/scos/dev/developer-guides/development-guide/back-end/data-manipulation/data-enrichment/zed-ui-tables/t-working-table.html
+                            - title: Adding Buttons to Zed Tables
+                              url: /docs/scos/dev/developer-guides/development-guide/back-end/data-manipulation/data-enrichment/zed-ui-tables/t-add-button-ta.html
+                              include_versions:
+                                - '201903.0'
+                            - title: Creating and configuring Zed tables
+                              url: /docs/scos/dev/developer-guides/development-guide/back-end/data-manipulation/data-enrichment/zed-ui-tables/creating-and-co.html
+                              include_versions:
+                                - '202108.0'
+                        - title: Messages and errors
+                          nested:
+                            - title: Handling Errors with ErrorHandler
+                              url: /docs/scos/dev/developer-guides/development-guide/back-end/data-manipulation/data-enrichment/messages-and-errors/error-handler.html
+                              include_versions:
+                                - '201903.0'
+                            - title: Showing Messages in Zed
+                              url: /docs/scos/dev/developer-guides/development-guide/back-end/data-manipulation/data-enrichment/messages-and-errors/flash-messenger.html
+                              include_versions:
+                                - '201903.0'
+                            - title: Registering a new Service
+                              url: /docs/scos/dev/developer-guides/development-guide/back-end/data-manipulation/data-enrichment/messages-and-errors/service.html
+                              include_versions:
+                                - '201903.0'
+                            - title: Handling Internal Server Messages
+                              url: /docs/scos/dev/developer-guides/development-guide/back-end/data-manipulation/data-enrichment/messages-and-errors/internal-server.html
+                              include_versions:
+                                - '201903.0'
+                        - title: Factory
+                          nested:
+                            - title: Creating Instances of Classes- Factory
+                              url: /docs/scos/dev/developer-guides/development-guide/back-end/data-manipulation/data-enrichment/factory/factory.html
+                            - title: Injecting Dependencies within Factories-
+                                Container Globals
+                              url: /docs/scos/dev/developer-guides/development-guide/back-end/data-manipulation/data-enrichment/factory/container-globa.html
+                              include_versions:
+                                - '201811.0'
+                                - '201903.0'
+                                - '201907.0'
+                                - '202001.0'
+                                - '202005.0'
+                            - title: Creating Instances of classes- factory
+                              url: /docs/scos/dev/developer-guides/development-guide/back-end/data-manipulation/data-enrichment/factory/factory.html
+                              include_versions:
+                                - '202108.0'
+                            - title: Injecting dependencies within factories-
+                                container globals
+                              url: /docs/scos/dev/developer-guides/development-guide/back-end/data-manipulation/data-enrichment/factory/container-globa.html
+                              include_versions:
+                                - '202009.0'
+                                - '202108.0'
+                        - title: Creating Forms
+                          url: /docs/scos/dev/developer-guides/development-guide/back-end/data-manipulation/data-enrichment/t-working-forms.html
+                          include_versions:
+                            - '201811.0'
+                            - '201903.0'
+                            - '201907.0'
+                        - title: Adding Navigation in the Back Office
+                          url: /docs/scos/dev/developer-guides/development-guide/back-end/data-manipulation/data-enrichment/adding-navigati.html
+                          include_versions:
+                            - '202005.0'
+                            - '202009.0'
+                            - '202108.0'
+                    - title: Queue
+                      nested:
+                        - title: Queue Pool
+                          url: /docs/scos/dev/developer-guides/development-guide/back-end/data-manipulation/queue/queue-pool.html
+                          include_versions:
+                            - '202001.0'
+                            - '202005.0'
+                            - '202009.0'
+                            - '202108.0'
+                        - title: Queue
+                          url: /docs/scos/dev/developer-guides/development-guide/back-end/data-manipulation/queue/queue.html
+                          include_versions:
+                            - '202001.0'
+                            - '202005.0'
+                            - '202009.0'
+                            - '202108.0'
+                        - title: Integrating RabbitMQ Headers in Queue Messages
+                          url: /docs/scos/dev/developer-guides/development-guide/back-end/data-manipulation/queue/rabbitmq-header.html
+                          include_versions:
+                            - '202001.0'
+                            - '202005.0'
+                            - '202009.0'
+                            - '202108.0'
+                    - title: Payment methods
+                      nested:
+                        - title: Direct Debit Example Implementation
+                          nested:
+                            - title: Implementing Direct Debit Payment
+                              url: /docs/scos/dev/developer-guides/development-guide/back-end/data-manipulation/payment-methods/direct-debit-example-implementation/ht-implement-dd.html
+                            - title: Integrate Direct Debit into Checkout
+                              url: /docs/scos/dev/developer-guides/development-guide/back-end/data-manipulation/payment-methods/direct-debit-example-implementation/dd-checkout-imp.html
+                            - title: Implementation of Direct Debit in the Shared
+                                Layer
+                              url: /docs/scos/dev/developer-guides/development-guide/back-end/data-manipulation/payment-methods/direct-debit-example-implementation/dd-shared-imple.html
+                            - title: Testing Your Direct Debit Implementation
+                              url: /docs/scos/dev/developer-guides/development-guide/back-end/data-manipulation/payment-methods/direct-debit-example-implementation/dd-test-impleme.html
+                            - title: Implementation of Direct Debit in Zed
+                              url: /docs/scos/dev/developer-guides/development-guide/back-end/data-manipulation/payment-methods/direct-debit-example-implementation/dd-be-implement.html
+                              include_versions:
+                                - '201903.0'
+                            - title: Implementation of Direct Debit in Yves
+                              url: /docs/scos/dev/developer-guides/development-guide/back-end/data-manipulation/payment-methods/direct-debit-example-implementation/dd-fe-implement.html
+                            - title: HowTo - Implement Direct Debit Payment
+                              url: /docs/scos/dev/developer-guides/development-guide/back-end/data-manipulation/payment-methods/direct-debit-example-implementation/ht-implement-dd.html
+                              include_versions:
+                                - '201811.0'
+                            - title: HowTo - Integrate the Direct Debit into Checkout
+                              url: /docs/scos/dev/developer-guides/development-guide/back-end/data-manipulation/payment-methods/direct-debit-example-implementation/dd-checkout-imp.html
+                              include_versions:
+                                - '201811.0'
+                            - title: HowTo - Implement the Direct Debit in Shared
+                                Layer
+                              url: /docs/scos/dev/developer-guides/development-guide/back-end/data-manipulation/payment-methods/direct-debit-example-implementation/dd-shared-imple.html
+                              include_versions:
+                                - '201811.0'
+                            - title: HowTo - Test the Direct Debit Implementation
+                              url: /docs/scos/dev/developer-guides/development-guide/back-end/data-manipulation/payment-methods/direct-debit-example-implementation/dd-test-impleme.html
+                              include_versions:
+                                - '201811.0'
+                            - title: HowTo - Implement the Direct Debit in Front-end
+                              url: /docs/scos/dev/developer-guides/development-guide/back-end/data-manipulation/payment-methods/direct-debit-example-implementation/dd-fe-implement.html
+                              include_versions:
+                                - '201811.0'
+                        - title: Prepayment
+                          nested:
+                            - title: Integrating Prepayment into Checkout
+                              url: /docs/scos/dev/developer-guides/development-guide/back-end/data-manipulation/payment-methods/prepayment/ht-prepayment-c.html
+                              include_versions:
+                                - '201903.0'
+                            - title: Implementing Prepayment
+                              url: /docs/scos/dev/developer-guides/development-guide/back-end/data-manipulation/payment-methods/prepayment/ht-implement-pr.html
+                              include_versions:
+                                - '201903.0'
+                            - title: Implementing Prepayment in Back End
+                              url: /docs/scos/dev/developer-guides/development-guide/back-end/data-manipulation/payment-methods/prepayment/ht-prepayment-b.html
+                              include_versions:
+                                - '201903.0'
+                            - title: Implement Prepayment in Front End
+                              url: /docs/scos/dev/developer-guides/development-guide/back-end/data-manipulation/payment-methods/prepayment/ht-prepayment-f.html
+                              include_versions:
+                                - '201903.0'
+                            - title: Testing the Prepayment Implementation
+                              url: /docs/scos/dev/developer-guides/development-guide/back-end/data-manipulation/payment-methods/prepayment/ht-prepayment-t.html
+                              include_versions:
+                                - '201903.0'
+                            - title: Implementing Prepayment in Shared Layer
+                              url: /docs/scos/dev/developer-guides/development-guide/back-end/data-manipulation/payment-methods/prepayment/ht-prepayment-s.html
+                              include_versions:
+                                - '201903.0'
+                        - title: Invoice
+                          nested:
+                            - title: Implementing Invoice Payment in Front End
+                              url: /docs/scos/dev/developer-guides/development-guide/back-end/data-manipulation/payment-methods/invoice/ht-invoice-paym.html
+                              include_versions:
+                                - '201903.0'
+                            - title: Implementing Invoice Payment
+                              url: /docs/scos/dev/developer-guides/development-guide/back-end/data-manipulation/payment-methods/invoice/ht-implement-in.html
+                              include_versions:
+                                - '201903.0'
+                        - title: Implementing a New Dummy Payment Method
+                          url: /docs/scos/dev/developer-guides/development-guide/back-end/data-manipulation/payment-methods/ht-implement-du.html
+                          include_versions:
+                            - '201811.0'
+                            - '201903.0'
+                            - '201907.0'
+                            - '202001.0'
+                            - '202005.0'
+                    - title: Order Management System
+                      nested:
+                        - title: Creating an Order Management System - Spryker
+                            Commerce OS
+                          url: /docs/scos/dev/developer-guides/development-guide/back-end/data-manipulation/order-management-system/t-oms-and-state.html
+                          include_versions:
+                            - '201811.0'
+                            - '201903.0'
+                            - '201907.0'
+                            - '202001.0'
+                        - title: Creating an Order Management System - Legacy
+                            Demoshop
+                          url: /docs/scos/dev/developer-guides/development-guide/back-end/data-manipulation/order-management-system/oms-state-machi.html
+                          include_versions:
+                            - '201811.0'
+                            - '201903.0'
+                            - '201907.0'
+                            - '202001.0'
+                    - title: Data ingestion
+                      nested:
+                        - title: Spryker Middleware
+                          url: /docs/scos/dev/developer-guides/development-guide/back-end/data-manipulation/data-ingestion/spryker-middlew.html
+                          include_versions:
+                            - '201903.0'
+                        - title: Structural preparations
+                          nested:
+                            - title: Creating, Using and Extending the Transfer
+                                Objects
+                              url: /docs/scos/dev/developer-guides/development-guide/back-end/data-manipulation/data-ingestion/structural-preparations/ht-use-transfer.html
+                              include_versions:
+                                - '201903.0'
+                                - '201907.0'
+                                - '202001.0'
+                                - '202005.0'
+                            - title: Extending the Database Schema
+                              url: /docs/scos/dev/developer-guides/development-guide/back-end/data-manipulation/data-ingestion/structural-preparations/t-extend-db-sch.html
+                              include_versions:
+                                - '201903.0'
+                            - title: Flysystem
+                              url: /docs/scos/dev/developer-guides/development-guide/back-end/data-manipulation/data-ingestion/structural-preparations/flysystem.html
+                              include_versions:
+                                - '201903.0'
+                            - title: File System
+                              url: /docs/scos/dev/developer-guides/development-guide/back-end/data-manipulation/data-ingestion/structural-preparations/filesystem.html
+                              include_versions:
+                                - '201903.0'
+                            - title: Creating, using, and extending the transfer
+                                objects
+                              url: /docs/scos/dev/developer-guides/development-guide/back-end/data-manipulation/data-ingestion/structural-preparations/ht-use-transfer.html
+                              include_versions:
+                                - '202009.0'
+                                - '202108.0'
+                        - title: Data Importers
+                          nested:
+                            - title: Creating a Data Importer
+                              url: /docs/scos/dev/developer-guides/development-guide/back-end/data-manipulation/data-ingestion/data-importers/ht-data-import.html
+                              include_versions:
+                                - '201811.0'
+                                - '201903.0'
+                                - '201907.0'
+                                - '202001.0'
+                            - title: Data Importer Speed Optimization
+                              url: /docs/scos/dev/developer-guides/development-guide/back-end/data-manipulation/data-ingestion/data-importers/dataimporter-sp.html
+                              include_versions:
+                                - '201811.0'
+                                - '201903.0'
+                                - '201907.0'
+                                - '202001.0'
+                            - title: Importing Data with the Queue Data Importer
+                              url: /docs/scos/dev/developer-guides/development-guide/back-end/data-manipulation/data-ingestion/data-importers/importing-data-.html
+                              include_versions:
+                                - '202001.0'
+                            - title: Data Importers Overview and Implementation
+                              url: /docs/scos/dev/developer-guides/development-guide/back-end/data-manipulation/data-ingestion/data-importers/data-importers-.html
+                              include_versions:
+                                - '201811.0'
+                                - '201903.0'
+                                - '201907.0'
+                                - '202001.0'
+                    - title: Event
+                      nested:
+                        - title: Configuring an Events Queue
+                          url: /docs/scos/dev/developer-guides/development-guide/back-end/data-manipulation/event/event-configure.html
+                          include_versions:
+                            - '202001.0'
+                            - '202005.0'
+                            - '202009.0'
+                            - '202108.0'
+                        - title: Event
+                          url: /docs/scos/dev/developer-guides/development-guide/back-end/data-manipulation/event/event.html
+                          include_versions:
+                            - '202001.0'
+                            - '202005.0'
+                            - '202009.0'
+                            - '202108.0'
+                        - title: Listening to Events
+                          url: /docs/scos/dev/developer-guides/development-guide/back-end/data-manipulation/event/event-listen.html
+                          include_versions:
+                            - '202001.0'
+                            - '202005.0'
+                            - '202009.0'
+                            - '202108.0'
+                        - title: Adding Events
+                          url: /docs/scos/dev/developer-guides/development-guide/back-end/data-manipulation/event/event-adding.html
+                          include_versions:
+                            - '202001.0'
+                            - '202005.0'
+                            - '202009.0'
+                            - '202108.0'
+                    - title: Creating an Order Management System - Spryker Commerce
+                        OS
+                      url: /docs/scos/dev/developer-guides/development-guide/back-end/data-manipulation/t-oms-and-state.html
+                      include_versions:
+                        - '202005.0'
+                        - '202009.0'
+                        - '202108.0'
+                    - title: Configuration management
+                      url: /docs/scos/dev/developer-guides/development-guide/back-end/data-manipulation/configuration-m.html
+                      include_versions:
+                        - '202009.0'
+                        - '202108.0'
+                - title: Client
+                  nested:
+                    - title: Using and Configuring Redis as a Key-value Storage
+                      url: /docs/scos/dev/developer-guides/development-guide/back-end/client/redis-as-kv.html
+                      include_versions:
+                        - '202005.0'
+                        - '202009.0'
+                        - '202108.0'
+                    - title: Implementing a Client
+                      url: /docs/scos/dev/developer-guides/development-guide/back-end/client/implementing-a-.html
+                      include_versions:
+                        - '202005.0'
+                        - '202009.0'
+                        - '202108.0'
+                    - title: Client
+                      url: /docs/scos/dev/developer-guides/development-guide/back-end/client/client.html
+                      include_versions:
+                        - '202005.0'
+                        - '202009.0'
+                        - '202108.0'
+                - title: Running production
+                  url: /docs/scos/dev/developer-guides/development-guide/back-end/running-product.html
+                  include_versions:
+                    - '202009.0'
+                    - '202108.0'
+            - title: About the Development Guide
+              url: /docs/scos/dev/developer-guides/development-guide/about-the-devel.html
+              include_versions:
+                - '201903.0'
+            - title: Data export
+              nested:
+                - title: Exporting Data
+                  url: /docs/scos/dev/developer-guides/development-guide/data-export/exporting-data.html
+                  include_versions:
+                    - '202005.0'
+                    - '202009.0'
+                    - '202108.0'
+                - title: Data Export Orders .csv Files Format
+                  url: /docs/scos/dev/developer-guides/development-guide/data-export/data-export-ord.html
+                  include_versions:
+                    - '202005.0'
+                    - '202009.0'
+                    - '202108.0'
+            - title: Data import
+              nested:
+                - title: Creating a Data Importer
+                  url: /docs/scos/dev/developer-guides/development-guide/data-import/ht-data-import.html
+                  include_versions:
+                    - '202005.0'
+                    - '202009.0'
+                    - '202108.0'
+                - title: Data Importer Speed Optimization
+                  url: /docs/scos/dev/developer-guides/development-guide/data-import/dataimporter-sp.html
+                  include_versions:
+                    - '202005.0'
+                    - '202009.0'
+                    - '202108.0'
+                - title: Data import categories
+                  nested:
+                    - title: About Data Import Categories
+                      url: /docs/scos/dev/developer-guides/development-guide/data-import/data-import-categories/about-data-impo.html
+                      include_versions:
+                        - '202005.0'
+                        - '202009.0'
+                        - '202108.0'
+                    - title: Navigation setup
+                      nested:
+                        - title: Navigation Setup
+                          url: /docs/scos/dev/developer-guides/development-guide/data-import/data-import-categories/navigation-setup/navigation-setu.html
+                          include_versions:
+                            - '202005.0'
+                            - '202009.0'
+                            - '202108.0'
+                        - title: File details- navigation.csv
+                          url: /docs/scos/dev/developer-guides/development-guide/data-import/data-import-categories/navigation-setup/file-details-na.html
+                          include_versions:
+                            - '202005.0'
+                            - '202009.0'
+                            - '202108.0'
+                    - title: Miscellaneous
+                      nested:
+                        - title: File details- comment.csv
+                          url: /docs/scos/dev/developer-guides/development-guide/data-import/data-import-categories/miscellaneous/file-details-co.html
+                          include_versions:
+                            - '202005.0'
+                            - '202009.0'
+                            - '202108.0'
+                        - title: Miscellaneous
+                          url: /docs/scos/dev/developer-guides/development-guide/data-import/data-import-categories/miscellaneous/miscellaneous.html
+                          include_versions:
+                            - '202005.0'
+                            - '202009.0'
+                            - '202108.0'
+                        - title: File details- mime_type.csv
+                          url: /docs/scos/dev/developer-guides/development-guide/data-import/data-import-categories/miscellaneous/file-details-mi.html
+                          include_versions:
+                            - '202005.0'
+                            - '202009.0'
+                            - '202108.0'
+                    - title: Catalog setup
+                      nested:
+                        - title: Products
+                          nested:
+                            - title: File details- product_management_attribute.csv
+                              url: /docs/scos/dev/developer-guides/development-guide/data-import/data-import-categories/catalog-setup/products/file-details-pr.html
+                              include_versions:
+                                - '202005.0'
+                                - '202009.0'
+                                - '202108.0'
+                            - title: Products
+                              url: /docs/scos/dev/developer-guides/development-guide/data-import/data-import-categories/catalog-setup/products/products-catego.html
+                              include_versions:
+                                - '202005.0'
+                                - '202009.0'
+                                - '202108.0'
+                        - title: Stocks
+                          nested:
+                            - title: File details- product_stock.csv
+                              url: /docs/scos/dev/developer-guides/development-guide/data-import/data-import-categories/catalog-setup/stocks/file-details-pr.html
+                              include_versions:
+                                - '202005.0'
+                                - '202009.0'
+                                - '202108.0'
+                            - title: Stocks
+                              url: /docs/scos/dev/developer-guides/development-guide/data-import/data-import-categories/catalog-setup/stocks/stocks.html
+                              include_versions:
+                                - '202005.0'
+                                - '202009.0'
+                                - '202108.0'
+                        - title: Catalog Setup
+                          url: /docs/scos/dev/developer-guides/development-guide/data-import/data-import-categories/catalog-setup/catalog-setup.html
+                          include_versions:
+                            - '202005.0'
+                            - '202009.0'
+                            - '202108.0'
+                        - title: Categories
+                          nested:
+                            - title: File details- category_template.csv
+                              url: /docs/scos/dev/developer-guides/development-guide/data-import/data-import-categories/catalog-setup/categories/file-details-ca.html
+                              include_versions:
+                                - '202005.0'
+                                - '202009.0'
+                                - '202108.0'
+                            - title: Categories
+                              url: /docs/scos/dev/developer-guides/development-guide/data-import/data-import-categories/catalog-setup/categories/categories.html
+                              include_versions:
+                                - '202005.0'
+                                - '202009.0'
+                                - '202108.0'
+                        - title: Pricing
+                          nested:
+                            - title: Pricing
+                              url: /docs/scos/dev/developer-guides/development-guide/data-import/data-import-categories/catalog-setup/pricing/pricing.html
+                              include_versions:
+                                - '202005.0'
+                                - '202009.0'
+                                - '202108.0'
+                            - title: File details- product_price_schedule.csv
+                              url: /docs/scos/dev/developer-guides/development-guide/data-import/data-import-categories/catalog-setup/pricing/file-details-pr.html
+                              include_versions:
+                                - '202005.0'
+                                - '202009.0'
+                                - '202108.0'
+                    - title: Content Management
+                      nested:
+                        - title: File details- content_product_abstract_list.csv
+                          url: /docs/scos/dev/developer-guides/development-guide/data-import/data-import-categories/content-management/file-details-co.html
+                          include_versions:
+                            - '202005.0'
+                            - '202009.0'
+                            - '202108.0'
+                        - title: Content Management
+                          url: /docs/scos/dev/developer-guides/development-guide/data-import/data-import-categories/content-management/content-managem.html
+                          include_versions:
+                            - '202005.0'
+                            - '202009.0'
+                            - '202108.0'
+                        - title: File details- cms_block_category.csv
+                          url: /docs/scos/dev/developer-guides/development-guide/data-import/data-import-categories/content-management/file-details-cm.html
+                          include_versions:
+                            - '202005.0'
+                            - '202009.0'
+                            - '202108.0'
+                    - title: Commerce setup
+                      nested:
+                        - title: File details- warehouse_store.csv
+                          url: /docs/scos/dev/developer-guides/development-guide/data-import/data-import-categories/commerce-setup/file-details-wa.html
+                          include_versions:
+                            - '202005.0'
+                            - '202009.0'
+                            - '202108.0'
+                        - title: File details- tax.csv
+                          url: /docs/scos/dev/developer-guides/development-guide/data-import/data-import-categories/commerce-setup/file-details-ta.html
+                          include_versions:
+                            - '202005.0'
+                            - '202009.0'
+                            - '202108.0'
+                        - title: File details- payment_method_store.csv
+                          url: /docs/scos/dev/developer-guides/development-guide/data-import/data-import-categories/commerce-setup/file-details-pa.html
+                          include_versions:
+                            - '202005.0'
+                            - '202009.0'
+                            - '202108.0'
+                        - title: File details- sales_order_threshold.csv
+                          url: /docs/scos/dev/developer-guides/development-guide/data-import/data-import-categories/commerce-setup/file-details-sa.html
+                          include_versions:
+                            - '202005.0'
+                            - '202009.0'
+                            - '202108.0'
+                        - title: Commerce Setup
+                          url: /docs/scos/dev/developer-guides/development-guide/data-import/data-import-categories/commerce-setup/commerce-setup.html
+                          include_versions:
+                            - '202005.0'
+                            - '202009.0'
+                            - '202108.0'
+                        - title: File details- glossary.csv
+                          url: /docs/scos/dev/developer-guides/development-guide/data-import/data-import-categories/commerce-setup/file-details-gl.html
+                          include_versions:
+                            - '202005.0'
+                            - '202009.0'
+                            - '202108.0'
+                        - title: File details- currency.csv
+                          url: /docs/scos/dev/developer-guides/development-guide/data-import/data-import-categories/commerce-setup/file-details-cu.html
+                          include_versions:
+                            - '202005.0'
+                            - '202009.0'
+                            - '202108.0'
+                        - title: File details- shipment_price.csv
+                          url: /docs/scos/dev/developer-guides/development-guide/data-import/data-import-categories/commerce-setup/file-details-sh.html
+                          include_versions:
+                            - '202005.0'
+                            - '202009.0'
+                        - title: File details- warehouse_address.csv
+                          url: /docs/scos/dev/developer-guides/development-guide/data-import/data-import-categories/commerce-setup/file-details-wa-1-.html
+                          include_versions:
+                            - '202108.0'
+                        - title: File details- order-status.csv
+                          url: /docs/scos/dev/developer-guides/development-guide/data-import/data-import-categories/commerce-setup/file-details-or.html
+                          include_versions:
+                            - '202108.0'
+                        - title: File details- shipment_method_store.csv
+                          url: /docs/scos/dev/developer-guides/development-guide/data-import/data-import-categories/commerce-setup/file-details-sh.html
+                          include_versions:
+                            - '202108.0'
+                    - title: Merchandising setup
+                      nested:
+                        - title: Product merchandising
+                          nested:
+                            - title: File details- product_quantity.csv
+                              url: /docs/scos/dev/developer-guides/development-guide/data-import/data-import-categories/merchandising-setup/product-merchandising/file-details-pr.html
+                              include_versions:
+                                - '202005.0'
+                            - title: Product Merchandising
+                              url: /docs/scos/dev/developer-guides/development-guide/data-import/data-import-categories/merchandising-setup/product-merchandising/product-merchan.html
+                              include_versions:
+                                - '202005.0'
+                                - '202009.0'
+                                - '202108.0'
+                            - title: File details- product_alternative.csv
+                              url: /docs/scos/dev/developer-guides/development-guide/data-import/data-import-categories/merchandising-setup/product-merchandising/file-details-pr.html
+                              include_versions:
+                                - '202009.0'
+                                - '202108.0'
+                            - title: File details- product_label_store.csv
+                              url: /docs/scos/dev/developer-guides/development-guide/data-import/data-import-categories/merchandising-setup/product-merchandising/file-details-pr-1-.html
+                              include_versions:
+                                - '202009.0'
+                                - '202108.0'
+                        - title: Merchandising Setup
+                          url: /docs/scos/dev/developer-guides/development-guide/data-import/data-import-categories/merchandising-setup/merchandising-s.html
+                          include_versions:
+                            - '202005.0'
+                            - '202009.0'
+                            - '202108.0'
+                        - title: Discounts
+                          nested:
+                            - title: Discounts
+                              url: /docs/scos/dev/developer-guides/development-guide/data-import/data-import-categories/merchandising-setup/discounts/discounts.html
+                              include_versions:
+                                - '202005.0'
+                                - '202009.0'
+                                - '202108.0'
+                            - title: File details- discount.csv
+                              url: /docs/scos/dev/developer-guides/development-guide/data-import/data-import-categories/merchandising-setup/discounts/file-details-di.html
+                              include_versions:
+                                - '202005.0'
+                                - '202009.0'
+                                - '202108.0'
+                    - title: Special product types
+                      nested:
+                        - title: Gift cards
+                          nested:
+                            - title: Gift Cards
+                              url: /docs/scos/dev/developer-guides/development-guide/data-import/data-import-categories/special-product-types/gift-cards/gift-cards-impo.html
+                              include_versions:
+                                - '202005.0'
+                                - '202009.0'
+                                - '202108.0'
+                            - title: File details-
+                                gift_card_abstract_configuration.csv
+                              url: /docs/scos/dev/developer-guides/development-guide/data-import/data-import-categories/special-product-types/gift-cards/file-details-gi.html
+                              include_versions:
+                                - '202005.0'
+                                - '202009.0'
+                                - '202108.0'
+                        - title: Special Product Types
+                          url: /docs/scos/dev/developer-guides/development-guide/data-import/data-import-categories/special-product-types/special-product.html
+                          include_versions:
+                            - '202005.0'
+                            - '202009.0'
+                        - title: Product options
+                          nested:
+                            - title: File details- product_option_price.csv
+                              url: /docs/scos/dev/developer-guides/development-guide/data-import/data-import-categories/special-product-types/product-options/file-details-pr.html
+                              include_versions:
+                                - '202005.0'
+                                - '202009.0'
+                                - '202108.0'
+                            - title: Product Options
+                              url: /docs/scos/dev/developer-guides/development-guide/data-import/data-import-categories/special-product-types/product-options/product-options.html
+                              include_versions:
+                                - '202005.0'
+                                - '202009.0'
+                                - '202108.0'
+                        - title: Special product types import category
+                          url: /docs/scos/dev/developer-guides/development-guide/data-import/data-import-categories/special-product-types/special-product.html
+                          include_versions:
+                            - '202108.0'
+                        - title: Configurable Product import category
+                          nested:
+                            - title: File details-
+                                product_concrete_pre_configuration.csv
+                              url: /docs/scos/dev/developer-guides/development-guide/data-import/data-import-categories/special-product-types/configurable-product-import-category/file-details-pr.html
+                              include_versions:
+                                - '202108.0'
+                            - title: Configurable Product data import
+                              url: /docs/scos/dev/developer-guides/development-guide/data-import/data-import-categories/special-product-types/configurable-product-import-category/configurable-pr.html
+                              include_versions:
+                                - '202108.0'
+                - title: Importing Data with the Queue Data Importer
+                  url: /docs/scos/dev/developer-guides/development-guide/data-import/importing-data-.html
+                  include_versions:
+                    - '202005.0'
+                - title: Importing Demo Shop Data
+                  nested:
+                    - title: Execution Order of Data Importers in Demo Shop
+                      url: /docs/scos/dev/developer-guides/development-guide/data-import/importing-demo-shop-data/execution-order.html
+                      include_versions:
+                        - '202005.0'
+                    - title: About Demo Shop Data Import
+                      url: /docs/scos/dev/developer-guides/development-guide/data-import/importing-demo-shop-data/about-demo-shop.html
+                      include_versions:
+                        - '202005.0'
+                - title: Demo Shop Data Import Categories
+                  url: /docs/scos/dev/developer-guides/development-guide/data-import/data-import-cat.html
+                  include_versions:
+                    - '202005.0'
+                - title: Data Importers Overview and Implementation
+                  url: /docs/scos/dev/developer-guides/development-guide/data-import/data-importers-.html
+                  include_versions:
+                    - '202005.0'
+                    - '202009.0'
+                    - '202108.0'
+                - title: Importing Product Data With a Single File
+                  url: /docs/scos/dev/developer-guides/development-guide/data-import/importing-produ.html
+                  include_versions:
+                    - '202009.0'
+                    - '202108.0'
+                - title: Importing Data with a Configuration File
+                  url: /docs/scos/dev/developer-guides/development-guide/data-import/importing-data-.html
+                  include_versions:
+                    - '202009.0'
+                    - '202108.0'
+                - title: Demo Shop data import
+                  nested:
+                    - title: Execution Order of Data Importers in Demo Shop
+                      url: /docs/scos/dev/developer-guides/development-guide/data-import/demo-shop-data-import/execution-order.html
+                      include_versions:
+                        - '202009.0'
+                        - '202108.0'
+                    - title: Importing Demo Shop data
+                      url: /docs/scos/dev/developer-guides/development-guide/data-import/demo-shop-data-import/importing-demo-.html
+                      include_versions:
+                        - '202009.0'
+                        - '202108.0'
+            - title: Glue API
+              nested:
+                - title: Security and Authentication
+                  url: /docs/scos/dev/developer-guides/development-guide/glue-api/security-and-au.html
+                  include_versions:
+                    - '202005.0'
+                    - '202009.0'
+                    - '202108.0'
+                - title: Glue Spryks
+                  url: /docs/scos/dev/developer-guides/development-guide/glue-api/glue-spryks.html
+                  include_versions:
+                    - '202005.0'
+                    - '202009.0'
+                    - '202108.0'
+                - title: Glue Infrastructure
+                  url: /docs/scos/dev/developer-guides/development-guide/glue-api/glue-infrastruc.html
+                  include_versions:
+                    - '202005.0'
+                    - '202009.0'
+                    - '202108.0'
+        - title: About the Developer Guides
+          url: /docs/scos/dev/developer-guides/about-developer.html
+          include_versions:
+            - '201811.0'
+            - '201903.0'
+            - '201907.0'
+            - '202001.0'
+            - '202005.0'
+        - title: Architecture guide
+          nested:
+            - title: Modularity and Shop Suite
+              url: /docs/scos/dev/developer-guides/architecture-guide/modularity-and-.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+                - '201907.0'
+                - '202001.0'
+                - '202005.0'
+            - title: About the Architecture Guide
+              url: /docs/scos/dev/developer-guides/architecture-guide/about-the-archi.html
+              include_versions:
+                - '201903.0'
+            - title: Conceptual Overview
+              url: /docs/scos/dev/developer-guides/architecture-guide/concept-overvie.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+                - '201907.0'
+                - '202001.0'
+                - '202005.0'
+            - title: Commerce OS and Frontend Apps
+              url: /docs/scos/dev/developer-guides/architecture-guide/commerce-os-and.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+                - '201907.0'
+                - '202001.0'
+            - title: Programming Concepts
+              url: /docs/scos/dev/developer-guides/architecture-guide/programming-con.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+                - '201907.0'
+                - '202001.0'
+                - '202005.0'
+            - title: Module API
+              nested:
+                - title: Definition of Module API
+                  url: /docs/scos/dev/developer-guides/architecture-guide/module-api/definition-api.html
+                  include_versions:
+                    - '201903.0'
+                - title: Performance and Scalability
+                  url: /docs/scos/dev/developer-guides/architecture-guide/module-api/performance-sca.html
+                  include_versions:
+                    - '201903.0'
+                - title: Semantic Versioning- Major vs. Minor vs. Patch Release
+                  url: /docs/scos/dev/developer-guides/architecture-guide/module-api/major-minor-pat.html
+                  include_versions:
+                    - '202001.0'
+                    - '202005.0'
+                    - '202009.0'
+                    - '202108.0'
+                - title: Using ~ Composer Constraint for Customized Modules
+                  url: /docs/scos/dev/developer-guides/architecture-guide/module-api/using-composer-.html
+                  include_versions:
+                    - '201903.0'
+                - title: Major vs. Minor vs. Patch Release
+                  url: /docs/scos/dev/developer-guides/architecture-guide/module-api/major-minor-pat.html
+                  include_versions:
+                    - '201811.0'
+                    - '201903.0'
+                    - '201907.0'
+            - title: Technology Stack
+              url: /docs/scos/dev/developer-guides/architecture-guide/technology-stac.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+                - '201907.0'
+                - '202001.0'
+                - '202005.0'
+            - title: Modules and layers
+              url: /docs/scos/dev/developer-guides/architecture-guide/modules-and-lay.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+            - title: Code buckets
+              url: /docs/scos/dev/developer-guides/architecture-guide/code-buckets.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+            - title: Conceptual overview
+              url: /docs/scos/dev/developer-guides/architecture-guide/conceptual-over.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+            - title: Programming concepts
+              url: /docs/scos/dev/developer-guides/architecture-guide/programming-con.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+            - title: Technology stack
+              url: /docs/scos/dev/developer-guides/architecture-guide/technology-stac.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+        - title: Code Contribution Guide
+          url: /docs/scos/dev/developer-guides/code-contributi.html
+          include_versions:
+            - '202005.0'
+        - title: Migrating Projects to the Latest Spryker Version with Spryker Jarvis
+          url: /docs/scos/dev/developer-guides/migrating-proje.html
+          include_versions:
+            - '202005.0'
+        - title: Docker SDK
+          nested:
+            - title: Configuring access to private repositories
+              url: /docs/scos/dev/developer-guides/docker-sdk/configuring-acc.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+            - title: Docker SDK configuration reference
+              url: /docs/scos/dev/developer-guides/docker-sdk/docker-sdk-conf.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+            - title: Docker SDK quick start guide
+              url: /docs/scos/dev/developer-guides/docker-sdk/docker-sdk-quic.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+            - title: Docker environment infrastructure
+              url: /docs/scos/dev/developer-guides/docker-sdk/docker-environm.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+            - title: Running tests with the Docker SDK
+              url: /docs/scos/dev/developer-guides/docker-sdk/running-tests-w.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+            - title: Choosing a mount mode
+              url: /docs/scos/dev/developer-guides/docker-sdk/choosing-a-moun.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+            - title: Configuring debugging in Docker
+              url: /docs/scos/dev/developer-guides/docker-sdk/configuring-deb.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+            - title: Configuring a mount mode
+              url: /docs/scos/dev/developer-guides/docker-sdk/configuring-a-m.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+            - title: Choosing a Docker SDK version
+              url: /docs/scos/dev/developer-guides/docker-sdk/choosing-a-dock.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+            - title: Docker SDK
+              url: /docs/scos/dev/developer-guides/docker-sdk/docker-sdk.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+            - title: Deploy file reference - 1.0
+              url: /docs/scos/dev/developer-guides/docker-sdk/deploy-file-ref.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+            - title: Configuring services
+              url: /docs/scos/dev/developer-guides/docker-sdk/configuring-ser.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+        - title: Developer getting started guide
+          url: /docs/scos/dev/developer-guides/dev-getting-sta.html
+          include_versions:
+            - '202009.0'
+            - '202108.0'
+        - title: Overview of the developer guides
+          url: /docs/scos/dev/developer-guides/overview-of-the.html
+          include_versions:
+            - '202009.0'
+            - '202108.0'
+        - title: Updating a Spryker-based project
+          url: /docs/scos/dev/developer-guides/updating-a-spry.html
+          include_versions:
+            - '202009.0'
+            - '202108.0'
+        - title: Analyzing and upgrading your project with Spryker Jarvis
+          url: /docs/scos/dev/developer-guides/analyzing-and-u.html
+          include_versions:
+            - '202009.0'
+            - '202108.0'
+        - title: Troubleshooting
+          nested:
+            - title: Spryker in Vagrant issues
+              nested:
+                - title: Frontend issues
+                  nested:
+                    - title: NPM error during installation
+                      url: /docs/scos/dev/developer-guides/troubleshooting/spryker-in-vagrant-issues/frontend-issues/npm-error-durin.html
+                      include_versions:
+                        - '202009.0'
+                        - '202108.0'
+                - title: Troubleshooting Spryker in Vagrant installation issues
+                  url: /docs/scos/dev/developer-guides/troubleshooting/spryker-in-vagrant-issues/troubleshooting.html
+                  include_versions:
+                    - '202009.0'
+                    - '202108.0'
+                - title: Other Spryker in Vagrant issues
+                  nested:
+                    - title: .NFS files crash my console commands
+                      url: /docs/scos/dev/developer-guides/troubleshooting/spryker-in-vagrant-issues/other-spryker-in-vagrant-issues/nfs-files-crash.html
+                      include_versions:
+                        - '202009.0'
+                        - '202108.0'
+                    - title: Too many open files in Dev VM
+                      url: /docs/scos/dev/developer-guides/troubleshooting/spryker-in-vagrant-issues/other-spryker-in-vagrant-issues/too-many-open-f.html
+                      include_versions:
+                        - '202009.0'
+                        - '202108.0'
+                    - title: Dev VM takes a lot of disk space (40+ GB)
+                      url: /docs/scos/dev/developer-guides/troubleshooting/spryker-in-vagrant-issues/other-spryker-in-vagrant-issues/dev-vm-takes-a-.html
+                      include_versions:
+                        - '202009.0'
+                        - '202108.0'
+                    - title: NFS export issues
+                      url: /docs/scos/dev/developer-guides/troubleshooting/spryker-in-vagrant-issues/other-spryker-in-vagrant-issues/nfs-export-issu.html
+                      include_versions:
+                        - '202009.0'
+                        - '202108.0'
+                    - title: Error on box image download
+                      url: /docs/scos/dev/developer-guides/troubleshooting/spryker-in-vagrant-issues/other-spryker-in-vagrant-issues/error-on-box-im.html
+                      include_versions:
+                        - '202009.0'
+                        - '202108.0'
+                    - title: VM stuck at 'Configuring and enabling network
+                        interfaces'
+                      url: /docs/scos/dev/developer-guides/troubleshooting/spryker-in-vagrant-issues/other-spryker-in-vagrant-issues/vm-stuck-at-con.html
+                      include_versions:
+                        - '202009.0'
+                        - '202108.0'
+                    - title: Failed to decode response- zlib_decode()- data error
+                      url: /docs/scos/dev/developer-guides/troubleshooting/spryker-in-vagrant-issues/other-spryker-in-vagrant-issues/failed-to-decod.html
+                      include_versions:
+                        - '202009.0'
+                        - '202108.0'
+                - title: Windows issues
+                  nested:
+                    - title: Windows- The host path of the shared folder is missing
+                      url: /docs/scos/dev/developer-guides/troubleshooting/spryker-in-vagrant-issues/windows-issues/windows-the-hos.html
+                      include_versions:
+                        - '202009.0'
+                        - '202108.0'
+                - title: MacOS issues
+                  nested:
+                    - title: Mac OSX- iterm2 (locale error)
+                      url: /docs/scos/dev/developer-guides/troubleshooting/spryker-in-vagrant-issues/macos-issues/mac-osx-iterm2-.html
+                      include_versions:
+                        - '202009.0'
+                        - '202108.0'
+                    - title: Mac OSX- Wrong curl version error
+                      url: /docs/scos/dev/developer-guides/troubleshooting/spryker-in-vagrant-issues/macos-issues/mac-osx-wrong-c.html
+                      include_versions:
+                        - '202009.0'
+                        - '202108.0'
+                    - title: Mac OSX- Installation fails or project folder can not be
+                        mounted due to SIP
+                      url: /docs/scos/dev/developer-guides/troubleshooting/spryker-in-vagrant-issues/macos-issues/mac-osx-install.html
+                      include_versions:
+                        - '202009.0'
+                        - '202108.0'
+                - title: Databases and services issues
+                  nested:
+                    - title: Peer authentication failed for user postgres
+                      url: /docs/scos/dev/developer-guides/troubleshooting/spryker-in-vagrant-issues/databases-and-services-issues/peer-authentica.html
+                      include_versions:
+                        - '202009.0'
+                        - '202108.0'
+                    - title: Setup MySQL Workbench to avoid port clashing with the
+                        host system
+                      url: /docs/scos/dev/developer-guides/troubleshooting/spryker-in-vagrant-issues/databases-and-services-issues/setup-mysql-wor.html
+                      include_versions:
+                        - '202009.0'
+                        - '202108.0'
+                    - title: Exception connecting to Redis
+                      url: /docs/scos/dev/developer-guides/troubleshooting/spryker-in-vagrant-issues/databases-and-services-issues/exception-conne.html
+                      include_versions:
+                        - '202009.0'
+                        - '202108.0'
+                    - title: My Elasticsearch dies
+                      url: /docs/scos/dev/developer-guides/troubleshooting/spryker-in-vagrant-issues/databases-and-services-issues/my-elasticsearc.html
+                      include_versions:
+                        - '202009.0'
+                        - '202108.0'
+            - title: Spryker in Docker issues
+              nested:
+                - title: Troubleshooting Spryker in Docker issues
+                  url: /docs/scos/dev/developer-guides/troubleshooting/spryker-in-docker-issues/troubleshooting.html
+                  include_versions:
+                    - '202009.0'
+                    - '202108.0'
+                - title: Troubleshooting debugging in Docker
+                  nested:
+                    - title: '`nc` command tells that the port is opened'
+                      url: /docs/scos/dev/developer-guides/troubleshooting/spryker-in-docker-issues/troubleshooting-debugging-in-docker/nc-command-tell.html
+                      include_versions:
+                        - '202009.0'
+                        - '202108.0'
+                    - title: Xdebug does not work
+                      url: /docs/scos/dev/developer-guides/troubleshooting/spryker-in-docker-issues/troubleshooting-debugging-in-docker/xdebug-does-not.html
+                      include_versions:
+                        - '202009.0'
+                        - '202108.0'
+                    - title: PHP `xdebug` extension is not active when accessing the
+                        website via a browser or curl
+                      url: /docs/scos/dev/developer-guides/troubleshooting/spryker-in-docker-issues/troubleshooting-debugging-in-docker/php-xdebug-exte-1-.html
+                      include_versions:
+                        - '202009.0'
+                        - '202108.0'
+                    - title: '`nc` command does not give any output'
+                      url: /docs/scos/dev/developer-guides/troubleshooting/spryker-in-docker-issues/troubleshooting-debugging-in-docker/nc-command-does.html
+                      include_versions:
+                        - '202009.0'
+                        - '202108.0'
+                    - title: PHP `xdebug` extension is not active in CLI
+                      url: /docs/scos/dev/developer-guides/troubleshooting/spryker-in-docker-issues/troubleshooting-debugging-in-docker/php-xdebug-exte.html
+                      include_versions:
+                        - '202009.0'
+                        - '202108.0'
+                - title: Troubleshooting running applications in Docker
+                  nested:
+                    - title: MacOS and Windows- file synchronization issues in
+                        Development mode
+                      url: /docs/scos/dev/developer-guides/troubleshooting/spryker-in-docker-issues/troubleshooting-running-applications-in-docker/macos-and-windo.html
+                      include_versions:
+                        - '202009.0'
+                        - '202108.0'
+                    - title: 413 Request Entity Too Large
+                      url: /docs/scos/dev/developer-guides/troubleshooting/spryker-in-docker-issues/troubleshooting-running-applications-in-docker/413-request-ent.html
+                      include_versions:
+                        - '202009.0'
+                        - '202108.0'
+                    - title: Nginx welcome page
+                      url: /docs/scos/dev/developer-guides/troubleshooting/spryker-in-docker-issues/troubleshooting-running-applications-in-docker/nginx-welcome-p.html
+                      include_versions:
+                        - '202009.0'
+                        - '202108.0'
+                    - title: Mutagen error
+                      url: /docs/scos/dev/developer-guides/troubleshooting/spryker-in-docker-issues/troubleshooting-running-applications-in-docker/mutagen-error.html
+                      include_versions:
+                        - '202009.0'
+                        - '202108.0'
+                    - title: Port is already occupied on host
+                      url: /docs/scos/dev/developer-guides/troubleshooting/spryker-in-docker-issues/troubleshooting-running-applications-in-docker/port-is-already.html
+                      include_versions:
+                        - '202009.0'
+                        - '202108.0'
+                    - title: Mutagen synchronization issue
+                      url: /docs/scos/dev/developer-guides/troubleshooting/spryker-in-docker-issues/troubleshooting-running-applications-in-docker/mutagen-synchro.html
+                      include_versions:
+                        - '202009.0'
+                        - '202108.0'
+                    - title: An application is not reachable via http
+                      url: /docs/scos/dev/developer-guides/troubleshooting/spryker-in-docker-issues/troubleshooting-running-applications-in-docker/an-application-.html
+                      include_versions:
+                        - '202009.0'
+                        - '202108.0'
+                - title: Troubleshooting Docker installation
+                  nested:
+                    - title: Docker daemon is not running
+                      url: /docs/scos/dev/developer-guides/troubleshooting/spryker-in-docker-issues/troubleshooting-docker-installation/docker-daemon-i.html
+                      include_versions:
+                        - '202009.0'
+                        - '202108.0'
+                    - title: An error during front end setup
+                      url: /docs/scos/dev/developer-guides/troubleshooting/spryker-in-docker-issues/troubleshooting-docker-installation/an-error-during.html
+                      include_versions:
+                        - '202009.0'
+                        - '202108.0'
+                    - title: Demo data was imported incorrectly
+                      url: /docs/scos/dev/developer-guides/troubleshooting/spryker-in-docker-issues/troubleshooting-docker-installation/demo-data-was-i.html
+                      include_versions:
+                        - '202009.0'
+                        - '202108.0'
+                    - title: docker-sync cannot start
+                      url: /docs/scos/dev/developer-guides/troubleshooting/spryker-in-docker-issues/troubleshooting-docker-installation/docker-sync-can.html
+                      include_versions:
+                        - '202009.0'
+                        - '202108.0'
+                    - title: Setup of new indexes throws an exception
+                      url: /docs/scos/dev/developer-guides/troubleshooting/spryker-in-docker-issues/troubleshooting-docker-installation/setup-of-new-in.html
+                      include_versions:
+                        - '202009.0'
+                        - '202108.0'
+                    - title: Vendor folder synchronization error
+                      url: /docs/scos/dev/developer-guides/troubleshooting/spryker-in-docker-issues/troubleshooting-docker-installation/vendor-folder-s.html
+                      include_versions:
+                        - '202009.0'
+                        - '202108.0'
+            - title: General technical issues
+              nested:
+                - title: ProcessTimedOutException after queue-task-start
+                  url: /docs/scos/dev/developer-guides/troubleshooting/general-technical-issues/processtimedout.html
+                  include_versions:
+                    - '202009.0'
+                    - '202108.0'
+                - title: RuntimeException- Failed to execute regex-
+                    PREG_JIT_STACKLIMIT_ERROR
+                  url: /docs/scos/dev/developer-guides/troubleshooting/general-technical-issues/runtimeexceptio.html
+                  include_versions:
+                    - '202009.0'
+                    - '202108.0'
+                - title: Class Silex/ControllerProviderInterface not found
+                  url: /docs/scos/dev/developer-guides/troubleshooting/general-technical-issues/class-silexcont.html
+                  include_versions:
+                    - '202009.0'
+                    - '202108.0'
+                - title: Fail whale on the front end
+                  url: /docs/scos/dev/developer-guides/troubleshooting/general-technical-issues/fail-whale-on-t.html
+                  include_versions:
+                    - '202009.0'
+                    - '202108.0'
+                - title: Troubleshooting general technical issues
+                  url: /docs/scos/dev/developer-guides/troubleshooting/general-technical-issues/troubleshooting.html
+                  include_versions:
+                    - '202009.0'
+                    - '202108.0'
+                - title: PHPStan memory issues
+                  url: /docs/scos/dev/developer-guides/troubleshooting/general-technical-issues/phpstan-memory-.html
+                  include_versions:
+                    - '202009.0'
+                    - '202108.0'
+                - title: Composer version 2 compatibility issues
+                  url: /docs/scos/dev/developer-guides/troubleshooting/general-technical-issues/composer-versio.html
+                  include_versions:
+                    - '202009.0'
+                    - '202108.0'
+                - title: A command fails with a `Killed` message
+                  url: /docs/scos/dev/developer-guides/troubleshooting/general-technical-issues/a-command-fails.html
+                  include_versions:
+                    - '202009.0'
+                    - '202108.0'
+                - title: Error response from daemon- OCI runtime create failed- ....
+                    \\\"no such file or directory\\\"\""- unknown
+                  url: /docs/scos/dev/developer-guides/troubleshooting/general-technical-issues/error-response-.html
+                  include_versions:
+                    - '202009.0'
+                    - '202108.0'
+                - title: 'Unable to resolve hosts for Mail, Jenkins, and RabbitMQ'
+                  url: /docs/scos/dev/developer-guides/troubleshooting/general-technical-issues/unable-to-resol.html
+                  include_versions:
+                    - '202009.0'
+                    - '202108.0'
+                - title: The spy_oms_transition_log table takes up too much space
+                  url: /docs/scos/dev/developer-guides/troubleshooting/general-technical-issues/the-spy-oms-tra.html
+                  include_versions:
+                    - '202009.0'
+                    - '202108.0'
+                - title: RabbitMQ- Zed.CRITICAL-
+                    PhpAmqpLib\Exception\AMQPChannelClosedException - Channel
+                    connection is closed
+                  url: /docs/scos/dev/developer-guides/troubleshooting/general-technical-issues/rabbitmq-zedcri.html
+                  include_versions:
+                    - '202009.0'
+                    - '202108.0'
+                - title: Router generates absolute URL with localhost
+                  url: /docs/scos/dev/developer-guides/troubleshooting/general-technical-issues/router-generate.html
+                  include_versions:
+                    - '202009.0'
+                    - '202108.0'
+                - title: No data on the Storefront
+                  url: /docs/scos/dev/developer-guides/troubleshooting/general-technical-issues/no-data-on-the-.html
+                  include_versions:
+                    - '202009.0'
+                    - '202108.0'
+                - title: ERROR- remove spryker_logs- volume is in use
+                  url: /docs/scos/dev/developer-guides/troubleshooting/general-technical-issues/error-remove-sp.html
+                  include_versions:
+                    - '202009.0'
+                    - '202108.0'
+        - title: Code contribution guide
+          url: /docs/scos/dev/developer-guides/code-contributi.html
+          include_versions:
+            - '202009.0'
+            - '202108.0'
+        - title: Spryker in Docker
+          nested:
+            - title: Dynamic Propel Configuration
+              url: /docs/scos/dev/developer-guides/spryker-in-docker/dynamic-propel-.html
+              include_versions:
+                - '201907.0'
+            - title: Environment Configuration Enhancement
+              url: /docs/scos/dev/developer-guides/spryker-in-docker/environment-con.html
+              include_versions:
+                - '201907.0'
+    - title: About Spryker
+      nested:
+        - title: What's new
+          nested:
+            - title: Supported Versions of PHP
+              url: /docs/scos/dev/about-spryker/whats-new/supported-versi.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+                - '201907.0'
+                - '202001.0'
+                - '202005.0'
+            - title: Documentation Updates
+              url: /docs/scos/dev/about-spryker/whats-new/documentation-u.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+                - '201907.0'
+                - '202001.0'
+                - '202005.0'
+            - title: Security Audit
+              url: /docs/scos/dev/about-spryker/whats-new/security-audit.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+                - '201907.0'
+                - '202001.0'
+                - '202005.0'
+            - title: Security Updates
+              url: /docs/scos/dev/about-spryker/whats-new/security-update.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+                - '201907.0'
+                - '202001.0'
+                - '202005.0'
+            - title: What's New
+              url: /docs/scos/dev/about-spryker/whats-new/whats-new.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+                - '201907.0'
+                - '202001.0'
+                - '202005.0'
+            - title: Roadmap
+              url: /docs/scos/dev/about-spryker/whats-new/roadmap.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+                - '201907.0'
+                - '202001.0'
+                - '202005.0'
+            - title: VAT Rates Reduction in Germany Between July 2020 and January
+                2021
+              url: /docs/scos/dev/about-spryker/whats-new/vat-rates-reduc.html
+              include_versions:
+                - '202005.0'
+        - title: Releases
+          nested:
+            - title: Releases
+              url: /docs/scos/dev/about-spryker/releases/releases.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+                - '201907.0'
+                - '202001.0'
+                - '202005.0'
+            - title: Archive
+              nested:
+                - title: 2017
+                  nested:
+                    - title: Release Notes - May - 2 2017
+                      url: /docs/scos/dev/about-spryker/releases/archive/2017/release-notes-m.html
+                      include_versions:
+                        - '201811.0'
+                        - '201903.0'
+                        - '201907.0'
+                        - '202001.0'
+                        - '202005.0'
+                    - title: Release Notes - August - 2 2017
+                      url: /docs/scos/dev/about-spryker/releases/archive/2017/release-notes-a.html
+                      include_versions:
+                        - '201811.0'
+                        - '201903.0'
+                        - '201907.0'
+                        - '202001.0'
+                        - '202005.0'
+                    - title: Release Notes - December - 2017
+                      url: /docs/scos/dev/about-spryker/releases/archive/2017/release-notes-d.html
+                      include_versions:
+                        - '201811.0'
+                        - '201903.0'
+                        - '201907.0'
+                        - '202001.0'
+                        - '202005.0'
+                    - title: Release Notes - September - 2 2017
+                      url: /docs/scos/dev/about-spryker/releases/archive/2017/release-notes-s.html
+                      include_versions:
+                        - '201811.0'
+                        - '201903.0'
+                        - '201907.0'
+                        - '202001.0'
+                        - '202005.0'
+                    - title: Release Notes - October - 1 2017
+                      url: /docs/scos/dev/about-spryker/releases/archive/2017/release-notes-o.html
+                      include_versions:
+                        - '201811.0'
+                        - '201903.0'
+                        - '201907.0'
+                        - '202001.0'
+                        - '202005.0'
+                    - title: Release Notes - November - 1 2017
+                      url: /docs/scos/dev/about-spryker/releases/archive/2017/release-notes-n.html
+                      include_versions:
+                        - '201811.0'
+                        - '201903.0'
+                        - '201907.0'
+                        - '202001.0'
+                        - '202005.0'
+                    - title: Release Notes - June - 2 2017
+                      url: /docs/scos/dev/about-spryker/releases/archive/2017/release-notes-j.html
+                      include_versions:
+                        - '201811.0'
+                        - '201903.0'
+                        - '201907.0'
+                        - '202001.0'
+                        - '202005.0'
+                - title: 2018
+                  nested:
+                    - title: Release Notes - March - 2018
+                      url: /docs/scos/dev/about-spryker/releases/archive/2018/release-notes-m.html
+                      include_versions:
+                        - '201811.0'
+                        - '201903.0'
+                        - '201907.0'
+                        - '202001.0'
+                        - '202005.0'
+                    - title: Release Notes - February - 1 2018
+                      url: /docs/scos/dev/about-spryker/releases/archive/2018/release-notes-f.html
+                      include_versions:
+                        - '201811.0'
+                        - '201903.0'
+                        - '201907.0'
+                        - '202001.0'
+                        - '202005.0'
+                    - title: Release Notes - April - 2018
+                      url: /docs/scos/dev/about-spryker/releases/archive/2018/release-notes-a.html
+                      include_versions:
+                        - '201811.0'
+                        - '201903.0'
+                        - '201907.0'
+                        - '202001.0'
+                        - '202005.0'
+                    - title: Release Notes - January - 2018
+                      url: /docs/scos/dev/about-spryker/releases/archive/2018/release-notes-j.html
+                      include_versions:
+                        - '201811.0'
+                        - '201903.0'
+                        - '201907.0'
+                        - '202001.0'
+                        - '202005.0'
+                - title: Releases Archive
+                  url: /docs/scos/dev/about-spryker/releases/archive/releases-archiv.html
+                  include_versions:
+                    - '201811.0'
+                    - '201903.0'
+                    - '201907.0'
+            - title: Release notes
+              nested:
+                - title: Release Notes
+                  url: /docs/scos/dev/about-spryker/releases/release-notes/release-notes.html
+                  include_versions:
+                    - '201811.0'
+                    - '201903.0'
+                    - '201907.0'
+                    - '202001.0'
+                    - '202005.0'
+                - title: Release notes 201903.0
+                  nested:
+                    - title: Security Release Notes 201903.0
+                      url: /docs/scos/dev/about-spryker/releases/release-notes/release-notes-201903.0/security-releas.html
+                      include_versions:
+                        - '201811.0'
+                        - '201903.0'
+                        - '201907.0'
+                        - '202001.0'
+                        - '202005.0'
+                    - title: Release Notes 201903.0
+                      url: /docs/scos/dev/about-spryker/releases/release-notes/release-notes-201903.0/release-notes-2.html
+                      include_versions:
+                        - '201811.0'
+                        - '201903.0'
+                        - '201907.0'
+                        - '202001.0'
+                        - '202005.0'
+                - title: Release notes 201907.0
+                  nested:
+                    - title: Security Release Notes 201907.0
+                      url: /docs/scos/dev/about-spryker/releases/release-notes/release-notes-201907.0/security-releas.html
+                      include_versions:
+                        - '201811.0'
+                        - '201903.0'
+                        - '201907.0'
+                        - '202001.0'
+                        - '202005.0'
+                    - title: Release Notes 201907.0
+                      url: /docs/scos/dev/about-spryker/releases/release-notes/release-notes-201907.0/release-notes-2.html
+                      include_versions:
+                        - '201811.0'
+                        - '201903.0'
+                        - '201907.0'
+                        - '202001.0'
+                        - '202005.0'
+                - title: Release Notes 2018.12.0
+                  url: /docs/scos/dev/about-spryker/releases/release-notes/release-notes-2.html
+                  include_versions:
+                    - '201811.0'
+                    - '201903.0'
+                    - '201907.0'
+                    - '202001.0'
+                    - '202005.0'
+                - title: Release notes 2018.11.0
+                  nested:
+                    - title: Security Release Notes 2018.11.0
+                      url: /docs/scos/dev/about-spryker/releases/release-notes/release-notes-2018.11.0/security-releas.html
+                      include_versions:
+                        - '201811.0'
+                        - '201903.0'
+                        - '201907.0'
+                        - '202001.0'
+                        - '202005.0'
+                    - title: Release Notes 2018.11.0
+                      url: /docs/scos/dev/about-spryker/releases/release-notes/release-notes-2018.11.0/release-notes-2.html
+                      include_versions:
+                        - '201811.0'
+                        - '201903.0'
+                        - '201907.0'
+                        - '202001.0'
+                        - '202005.0'
+                - title: Release notes 202001.0
+                  nested:
+                    - title: Security Release Notes 202001.0
+                      url: /docs/scos/dev/about-spryker/releases/release-notes/release-notes-202001.0/security-releas.html
+                      include_versions:
+                        - '202001.0'
+                        - '202005.0'
+                    - title: Release Notes 202001.0
+                      url: /docs/scos/dev/about-spryker/releases/release-notes/release-notes-202001.0/release-notes-2.html
+                      include_versions:
+                        - '202001.0'
+                        - '202005.0'
+                    - title: Known Issues 202001.0
+                      url: /docs/scos/dev/about-spryker/releases/release-notes/release-notes-202001.0/known-issues-20.html
+                      include_versions:
+                        - '202001.0'
+                        - '202005.0'
+                - title: 'Release notes Code Releases May, 2020'
+                  nested:
+                    - title: 'Release Notes- Code Releases May, 2020'
+                      url: /docs/scos/dev/about-spryker/releases/release-notes/release-notes-code-releases-may-2020/release-notes-c.html
+                      include_versions:
+                        - '202005.0'
+                    - title: 'Security Release Notes- Code Releases May, 2020'
+                      url: /docs/scos/dev/about-spryker/releases/release-notes/release-notes-code-releases-may-2020/security-releas.html
+                      include_versions:
+                        - '202005.0'
+            - title: Releases Archive
+              url: /docs/scos/dev/about-spryker/releases/releases-archiv.html
+              include_versions:
+                - '202001.0'
+                - '202005.0'
+        - title: Getting Support
+          url: /docs/scos/dev/about-spryker/getting-support.html
+          include_versions:
+            - '201811.0'
+            - '201903.0'
+            - '201907.0'
+            - '202001.0'
+            - '202005.0'
+        - title: Videos & Webinars
+          nested:
+            - title: B2C Demo Shop
+              url: /docs/scos/dev/about-spryker/videos-and-webinars/b2c-demo-shop.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+                - '201907.0'
+                - '202001.0'
+            - title: Legacy Demoshop
+              url: /docs/scos/dev/about-spryker/videos-and-webinars/legacy-demoshop.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+                - '201907.0'
+                - '202001.0'
+            - title: B2B Demo Shop
+              url: /docs/scos/dev/about-spryker/videos-and-webinars/b2b-demo-shop.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+                - '201907.0'
+                - '202001.0'
+            - title: Configure CMS pages in Spryker
+              url: /docs/scos/dev/about-spryker/videos-and-webinars/cms-pages-video.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+                - '201907.0'
+                - '202001.0'
+            - title: How to set up Company Structure in Spryker B2B Demo Shop
+              url: /docs/scos/dev/about-spryker/videos-and-webinars/how-to-setup-co.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+                - '201907.0'
+                - '202001.0'
+            - title: Manage Categories in Spryker
+              url: /docs/scos/dev/about-spryker/videos-and-webinars/manage-categori.html
+              include_versions:
+                - '202001.0'
+            - title: How to Use Shopping Lists in Spryker B2B Demo Shop
+              url: /docs/scos/dev/about-spryker/videos-and-webinars/how-to-use-shop.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+                - '201907.0'
+                - '202001.0'
+            - title: Navigation
+              url: /docs/scos/dev/about-spryker/videos-and-webinars/navigation-vide.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+                - '201907.0'
+                - '202001.0'
+            - title: How to set up Company Users and Roles in Spryker B2B Demo Shop
+              url: /docs/scos/dev/about-spryker/videos-and-webinars/how-to-setup-us.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+                - '201907.0'
+                - '202001.0'
+            - title: Spryker Videos
+              url: /docs/scos/dev/about-spryker/videos-and-webinars/videos.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+                - '201907.0'
+                - '202001.0'
+            - title: Configure Product Groups in Spryker
+              url: /docs/scos/dev/about-spryker/videos-and-webinars/product-groups.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+                - '201907.0'
+                - '202001.0'
+            - title: Configure CMS Blocks in Spryker
+              url: /docs/scos/dev/about-spryker/videos-and-webinars/cms-blocks.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+                - '201907.0'
+                - '202001.0'
+            - title: How to Configure Navigation in Spryker
+              url: /docs/scos/dev/about-spryker/videos-and-webinars/how-to-configur.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+                - '201907.0'
+                - '202001.0'
+            - title: Manage Products in Spryker
+              url: /docs/scos/dev/about-spryker/videos-and-webinars/product-managem.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+                - '201907.0'
+                - '202001.0'
+            - title: Configure Product Sets in Spryker
+              url: /docs/scos/dev/about-spryker/videos-and-webinars/product-sets-vi.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+                - '201907.0'
+                - '202001.0'
+            - title: Use Wishlists in Spryker
+              url: /docs/scos/dev/about-spryker/videos-and-webinars/wishlists-video.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+                - '201907.0'
+                - '202001.0'
+            - title: How to set up Agent Assist in Spryker B2B Demo Shop
+              url: /docs/scos/dev/about-spryker/videos-and-webinars/how-to-setup-ag.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+                - '201907.0'
+                - '202001.0'
+            - title: How to set up Merchants and Merchant Relationships in Spryker
+                B2B Demo Shop
+              url: /docs/scos/dev/about-spryker/videos-and-webinars/how-to-setup-me.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+                - '201907.0'
+                - '202001.0'
+            - title: Manage categories in Spryker
+              url: /docs/scos/dev/about-spryker/videos-and-webinars/manage-categori.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+                - '201907.0'
+        - title: Understanding Spryker Commerce OS
+          url: /docs/scos/dev/about-spryker/understanding-s.html
+          include_versions:
+            - '201811.0'
+            - '201903.0'
+            - '201907.0'
+            - '202001.0'
+        - title: FAQ
+          url: /docs/scos/dev/about-spryker/faq.html
+          include_versions:
+            - '201811.0'
+            - '201903.0'
+            - '201907.0'
+            - '202001.0'
+            - '202005.0'
+        - title: About Spryker Documentation
+          url: /docs/scos/dev/about-spryker/about-documenta.html
+          include_versions:
+            - '201811.0'
+            - '201903.0'
+            - '201907.0'
+            - '202001.0'
+            - '202005.0'
+        - title: Spryker Release Process
+          url: /docs/scos/dev/about-spryker/spryker-release.html
+          include_versions:
+            - '202001.0'
+            - '202005.0'
+        - title: B2C Suite
+          url: /docs/scos/dev/about-spryker/b2c-suite.html
+          include_versions:
+            - '202001.0'
+            - '202005.0'
+        - title: B2B Suite
+          url: /docs/scos/dev/about-spryker/b2b-suite.html
+          include_versions:
+            - '202001.0'
+            - '202005.0'
+        - title: Master Suite
+          url: /docs/scos/dev/about-spryker/master-suite.html
+          include_versions:
+            - '202001.0'
+            - '202005.0'
+        - title: About Spryker
+          url: /docs/scos/dev/about-spryker/about-spryker.html
+          include_versions:
+            - '201811.0'
+            - '201903.0'
+            - '201907.0'
+            - '202001.0'
+            - '202005.0'
+        - title: Feedback
+          url: /docs/scos/dev/about-spryker/feedback.html
+          include_versions:
+            - '201903.0'
+            - '201907.0'
+            - '202001.0'
+            - '202005.0'
+        - title: MVP Project Structuring
+          url: /docs/scos/dev/about-spryker/mvp-project-str.html
+          include_versions:
+            - '201811.0'
+            - '201903.0'
+            - '201907.0'
+            - '202001.0'
+            - '202005.0'
+        - title: Handling security issues
+          url: /docs/scos/dev/about-spryker/handling-securi.html
+          include_versions:
+            - '201811.0'
+            - '201903.0'
+            - '202001.0'
+            - '202005.0'
+        - title: Demo Shops
+          url: /docs/scos/dev/about-spryker/demoshops.html
+          include_versions:
+            - '201811.0'
+            - '201903.0'
+            - '201907.0'
+        - title: Spryker Videos
+          url: /docs/scos/dev/about-spryker/spryker-videos.html
+          include_versions:
+            - '202005.0'
+        - title: Security Support
+          url: /docs/scos/dev/about-spryker/handling-securi.html
+          include_versions:
+            - '201907.0'
+    - title: Features
+      nested:
+        - title: Gift cards
+          nested:
+            - title: Gift Card Purchase and Management
+              nested:
+                - title: Gift Card Purchase and Management
+                  url: /docs/scos/dev/features/gift-cards/gift-card-purchase-and-management/gift-card-purch.html
+                  include_versions:
+                    - '201811.0'
+                    - '201903.0'
+                    - '201907.0'
+                    - '202001.0'
+                    - '202005.0'
+                - title: Gift Cards Purchase and Redeeming
+                  url: /docs/scos/dev/features/gift-cards/gift-card-purchase-and-management/gift-cards-purc.html
+                  include_versions:
+                    - '201811.0'
+                    - '201903.0'
+                    - '201907.0'
+                    - '202001.0'
+                    - '202005.0'
+            - title: Gift Cards
+              url: /docs/scos/dev/features/gift-cards/gift-cards.html
+            - title: Gift cards
+              url: /docs/scos/dev/features/gift-cards/gift-cards.html
+              include_versions:
+                - '202009.0'
+            - title: Gift Cards feature overview
+              url: /docs/scos/dev/features/gift-cards/gift-cards-feat.html
+              include_versions:
+                - '202009.0'
+        - title: Catalog Management
+          nested:
+            - title: Product Catalog Management
+              url: /docs/scos/dev/features/catalog-management/product-catalog.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+                - '201907.0'
+                - '202001.0'
+            - title: Category Management
+              nested:
+                - title: Category Management Feature Overview
+                  url: /docs/scos/dev/features/catalog-management/category-management/category-manage.html
+                  include_versions:
+                    - '201903.0'
+                    - '201907.0'
+                    - '202001.0'
+                    - '202005.0'
+            - title: Category Pages
+              url: /docs/scos/dev/features/catalog-management/category-pages.html
+              include_versions:
+                - '202001.0'
+            - title: Product to Category Association
+              url: /docs/scos/dev/features/catalog-management/product-to-cate.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+                - '201907.0'
+                - '202001.0'
+            - title: Catalog Management
+              url: /docs/scos/dev/features/catalog-management/catalog-managem.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+                - '201907.0'
+                - '202001.0'
+                - '202005.0'
+            - title: Define Category Hierarchy
+              url: /docs/scos/dev/features/catalog-management/define-category.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+                - '201907.0'
+                - '202001.0'
+        - title: Internationalization
+          nested:
+            - title: Glossary Creation
+              nested:
+                - title: Glossary Creation
+                  url: /docs/scos/dev/features/internationalization/glossary-creation/glossary-creati.html
+                  include_versions:
+                    - '201811.0'
+                    - '201903.0'
+                    - '201907.0'
+                    - '202001.0'
+                    - '202005.0'
+                - title: Managing Glossary Keys
+                  url: /docs/scos/dev/features/internationalization/glossary-creation/glossary-keys.html
+                  include_versions:
+                    - '201811.0'
+                    - '201903.0'
+                    - '201907.0'
+                    - '202001.0'
+                    - '202005.0'
+                - title: How Translations are Managed
+                  url: /docs/scos/dev/features/internationalization/glossary-creation/glossary-how-tr.html
+                  include_versions:
+                    - '201811.0'
+                    - '201903.0'
+                    - '201907.0'
+                    - '202001.0'
+                    - '202005.0'
+            - title: Internationalization
+              url: /docs/scos/dev/features/internationalization/internationaliz.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+                - '201907.0'
+                - '202001.0'
+                - '202005.0'
+            - title: Multiple Stores
+              url: /docs/scos/dev/features/internationalization/multiple-stores.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+                - '201907.0'
+                - '202001.0'
+                - '202005.0'
+            - title: Multiple Currencies per Store
+              url: /docs/scos/dev/features/internationalization/multiple-curren.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+                - '201907.0'
+                - '202001.0'
+                - '202005.0'
+            - title: International Tax Rates and Sets
+              url: /docs/scos/dev/features/internationalization/international-t.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+                - '201907.0'
+                - '202001.0'
+                - '202005.0'
+        - title: Sample Suite and Custom Suite
+          nested:
+            - title: Choosing the Right Suite for You
+              url: /docs/scos/dev/features/sample-suite-and-custom-suite/choosing-the-ri.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+                - '201907.0'
+                - '202001.0'
+                - '202005.0'
+            - title: Sample Suite and Custom Suite
+              url: /docs/scos/dev/features/sample-suite-and-custom-suite/sample-suite-an.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+                - '201907.0'
+                - '202001.0'
+                - '202005.0'
+        - title: Order Management
+          nested:
+            - title: Reorder
+              url: /docs/scos/dev/features/order-management/reorder.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+                - '201907.0'
+                - '202001.0'
+                - '202005.0'
+            - title: URL
+              url: /docs/scos/dev/features/order-management/url.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+                - '201907.0'
+                - '202001.0'
+                - '202005.0'
+            - title: Order Processing
+              url: /docs/scos/dev/features/order-management/order-processin.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+                - '201907.0'
+                - '202001.0'
+            - title: Sales 5.0
+              url: /docs/scos/dev/features/order-management/sales-5-0.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+                - '201907.0'
+                - '202001.0'
+                - '202005.0'
+            - title: Reclamations
+              nested:
+                - title: Reclamations
+                  url: /docs/scos/dev/features/order-management/reclamations/reclamations.html
+                  include_versions:
+                    - '201903.0'
+                    - '201907.0'
+                    - '202001.0'
+                    - '202005.0'
+                - title: Reclamations Feature Overview
+                  url: /docs/scos/dev/features/order-management/reclamations/reclamations-fe.html
+                  include_versions:
+                    - '201903.0'
+                    - '201907.0'
+                    - '202001.0'
+                    - '202005.0'
+            - title: Offer Management
+              url: /docs/scos/dev/features/order-management/offer-managemen.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+                - '202001.0'
+                - '202005.0'
+            - title: Order Management
+              url: /docs/scos/dev/features/order-management/order-managemen.html
+              include_versions:
+                - '201903.0'
+            - title: OMS (Order Management System) Matrix
+              url: /docs/scos/dev/features/order-management/oms-matrix.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+                - '201907.0'
+                - '202001.0'
+                - '202005.0'
+            - title: Split Delivery
+              nested:
+                - title: Split Delivery Overview
+                  url: /docs/scos/dev/features/order-management/split-delivery/split-delivery-.html
+                  include_versions:
+                    - '202001.0'
+                    - '202005.0'
+                - title: Split Delivery
+                  url: /docs/scos/dev/features/order-management/split-delivery/split-delivery.html
+                  include_versions:
+                    - '202001.0'
+                    - '202005.0'
+            - title: Splittable order items
+              nested:
+                - title: Splittable Order Items
+                  url: /docs/scos/dev/features/order-management/splittable-order-items/splittable-orde.html
+                  include_versions:
+                    - '201811.0'
+                    - '201903.0'
+                    - '201907.0'
+                    - '202001.0'
+                    - '202005.0'
+                - title: Splittable order items
+                  url: /docs/scos/dev/features/order-management/splittable-order-items/splittable-orde.html
+                  include_versions:
+                    - '202009.0'
+            - title: Sales
+              url: /docs/scos/dev/features/order-management/sales.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+                - '201907.0'
+                - '202001.0'
+                - '202005.0'
+            - title: Step Engine
+              url: /docs/scos/dev/features/order-management/step-engine.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+                - '201907.0'
+                - '202001.0'
+                - '202005.0'
+            - title: Return management
+              nested:
+                - title: Return Management
+                  url: /docs/scos/dev/features/order-management/return-management/return-manageme.html
+                  include_versions:
+                    - '202005.0'
+            - title: Custom Order Reference
+              nested:
+                - title: Custom Order Reference
+                  url: /docs/scos/dev/features/order-management/custom-order-reference/custom-order-re.html
+                  include_versions:
+                    - '202005.0'
+            - title: Order Cancellation
+              nested:
+                - title: Order Cancellation
+                  url: /docs/scos/dev/features/order-management/order-cancellation/order-cancellat.html
+                  include_versions:
+                    - '202005.0'
+            - title: OMS (Order management system) matrix
+              url: /docs/scos/dev/features/order-management/oms-matrix.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+            - title: Order Management feature overview
+              nested:
+                - title: Custom Order Reference- module relations
+                  url: /docs/scos/dev/features/order-management/order-management-feature-overview/custom-order-re.html
+                  include_versions:
+                    - '202108.0'
+                - title: Split Delivery overview
+                  url: /docs/scos/dev/features/order-management/order-management-feature-overview/split-delivery-.html
+                  include_versions:
+                    - '202009.0'
+                    - '202108.0'
+                - title: Splittable Order Items overview
+                  url: /docs/scos/dev/features/order-management/order-management-feature-overview/splittable-orde.html
+                  include_versions:
+                    - '202009.0'
+                    - '202108.0'
+                - title: Order Cancellation overview
+                  url: /docs/scos/dev/features/order-management/order-management-feature-overview/order-cancellat.html
+                  include_versions:
+                    - '202009.0'
+                    - '202108.0'
+                - title: Sales module- reference information
+                  url: /docs/scos/dev/features/order-management/order-management-feature-overview/sales-module-re.html
+                  include_versions:
+                    - '202009.0'
+                    - '202108.0'
+                - title: Invoice Generation overview
+                  url: /docs/scos/dev/features/order-management/order-management-feature-overview/invoice-generat.html
+                  include_versions:
+                    - '202009.0'
+                    - '202108.0'
+                - title: Custom Order Reference overview
+                  url: /docs/scos/dev/features/order-management/order-management-feature-overview/custom-order-re.html
+                  include_versions:
+                    - '202009.0'
+        - title: Packaging & Measurement Units
+          nested:
+            - title: Packaging & Measurement Units
+              url: /docs/scos/dev/features/packaging-and-measurement-units/packaging-measu.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+                - '201907.0'
+                - '202001.0'
+                - '202005.0'
+            - title: Packaging units
+              nested:
+                - title: Packaging Units Feature Overview
+                  url: /docs/scos/dev/features/packaging-and-measurement-units/packaging-units/packaging-units.html
+                  include_versions:
+                    - '201811.0'
+                    - '201907.0'
+                    - '202001.0'
+                    - '202005.0'
+                - title: Packaging Units
+                  url: /docs/scos/dev/features/packaging-and-measurement-units/packaging-units/packaging-units.html
+                  include_versions:
+                    - '201903.0'
+            - title: Measurement units
+              nested:
+                - title: Measurement Units Feature Overview
+                  url: /docs/scos/dev/features/packaging-and-measurement-units/measurement-units/measurement-uni.html
+                  include_versions:
+                    - '201811.0'
+                    - '201903.0'
+                    - '201907.0'
+                    - '202001.0'
+                    - '202005.0'
+        - title: Overview of the feature guides
+          url: /docs/scos/dev/features/overview-of-the.html
+          include_versions:
+            - '202001.0'
+            - '202009.0'
+            - '202108.0'
+        - title: Inventory Management
+          nested:
+            - title: Inventory Management
+              url: /docs/scos/dev/features/inventory-management/inventory-manag.html
+            - title: Stock and Availability Management
+              url: /docs/scos/dev/features/inventory-management/stock-availabil.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+                - '201907.0'
+                - '202001.0'
+                - '202005.0'
+            - title: Inventory
+              url: /docs/scos/dev/features/inventory-management/about-inventory.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+                - '201907.0'
+                - '202001.0'
+                - '202005.0'
+            - title: Warehouse Management
+              url: /docs/scos/dev/features/inventory-management/multiple-wareho.html
+              include_versions:
+                - '202001.0'
+                - '202005.0'
+            - title: Multiple Warehouse Stock Management
+              url: /docs/scos/dev/features/inventory-management/multiple-wareho.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+                - '201907.0'
+            - title: Inventory Management feature overview
+              url: /docs/scos/dev/features/inventory-management/inventory-manag.html
+              include_versions:
+                - '202108.0'
+            - title: Reference informaton- AvailabilityStorage module overview
+              url: /docs/scos/dev/features/inventory-management/reference-infor.html
+              include_versions:
+                - '202108.0'
+            - title: Managing stocks in a multi-store environment- Best practices
+              url: /docs/scos/dev/features/inventory-management/managing-stocks.html
+              include_versions:
+                - '202108.0'
+        - title: Payment
+          nested:
+            - title: Refund Management
+              url: /docs/scos/dev/features/payment/refund-manageme.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+                - '201907.0'
+                - '202001.0'
+                - '202005.0'
+            - title: Payment
+              url: /docs/scos/dev/features/payment/payment.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+                - '201907.0'
+                - '202001.0'
+                - '202005.0'
+            - title: Dummy Payment
+              url: /docs/scos/dev/features/payment/dummy-payment.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+                - '201907.0'
+                - '202001.0'
+                - '202005.0'
+            - title: Multiple Payment Methods per Order
+              url: /docs/scos/dev/features/payment/multiple-paymen.html
+              include_versions:
+                - '202001.0'
+            - title: Payment Provider Integration
+              url: /docs/scos/dev/features/payment/payment-provide.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+                - '201907.0'
+                - '202001.0'
+                - '202005.0'
+            - title: Refund 2.0
+              url: /docs/scos/dev/features/payment/refund-2-0.html
+              include_versions:
+                - '201811.0'
+            - title: Multiple Payment Methods Per Order
+              url: /docs/scos/dev/features/payment/multiple-paymen.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+                - '201907.0'
+            - title: Payment Methods Overview
+              url: /docs/scos/dev/features/payment/multiple-paymen.html
+              include_versions:
+                - '202005.0'
+            - title: Refund
+              url: /docs/scos/dev/features/payment/refund.html
+              include_versions:
+                - '201903.0'
+                - '201907.0'
+        - title: Rating and Reviews
+          nested:
+            - title: Rating and Reviews
+              url: /docs/scos/dev/features/rating-and-reviews/rating-reviews.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+                - '201907.0'
+                - '202001.0'
+                - '202005.0'
+            - title: Rating and Review Management
+              url: /docs/scos/dev/features/rating-and-reviews/rating-revew-ma.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+                - '201907.0'
+                - '202001.0'
+                - '202005.0'
+        - title: Navigation
+          nested:
+            - title: Navigation Module
+              url: /docs/scos/dev/features/navigation/module-navigati.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+                - '201907.0'
+                - '202001.0'
+            - title: Navigation
+              url: /docs/scos/dev/features/navigation/navigation.html
+            - title: Product-Based Shop Navigation
+              url: /docs/scos/dev/features/navigation/product-based-s.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+                - '201907.0'
+                - '202001.0'
+            - title: Content-Based Shop Navigation
+              url: /docs/scos/dev/features/navigation/content-based-s.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+                - '201907.0'
+                - '202001.0'
+            - title: Hierarchical Navigation
+              url: /docs/scos/dev/features/navigation/hierarchical-na.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+                - '201907.0'
+                - '202001.0'
+            - title: Navigation feature overview
+              url: /docs/scos/dev/features/navigation/navigation-feat.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+            - title: Navigation module- reference information
+              url: /docs/scos/dev/features/navigation/navigation-modu.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+        - title: Tax
+          nested:
+            - title: Tax Module
+              url: /docs/scos/dev/features/tax/tax-module.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+                - '201907.0'
+                - '202001.0'
+                - '202005.0'
+            - title: Manage Tax Rates & Sets
+              url: /docs/scos/dev/features/tax/manage-tax-rate.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+                - '201907.0'
+                - '202001.0'
+                - '202005.0'
+            - title: Tax
+              url: /docs/scos/dev/features/tax/tax.html
+              include_versions:
+                - '201903.0'
+            - title: International Tax Rates & Sets
+              url: /docs/scos/dev/features/tax/international-t.html
+            - title: Tax feature overview
+              url: /docs/scos/dev/features/tax/tax-feature-ove.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+            - title: Reference information- Avalara integration—module relations
+              url: /docs/scos/dev/features/tax/reference-infor.html
+              include_versions:
+                - '202108.0'
+            - title: Tax module
+              url: /docs/scos/dev/features/tax/tax-module.html
+              include_versions:
+                - '202009.0'
+            - title: International tax rates and sets
+              url: /docs/scos/dev/features/tax/international-t.html
+              include_versions:
+                - '202009.0'
+        - title: Checkout
+          nested:
+            - title: Checkout
+              url: /docs/scos/dev/features/checkout/checkout.html
+              include_versions:
+                - '201903.0'
+            - title: Multi-Step Checkout
+              nested:
+                - title: Multi-Step Checkout
+                  url: /docs/scos/dev/features/checkout/multi-step-checkout/multi-step-chec.html
+                  include_versions:
+                    - '202001.0'
+                    - '202005.0'
+                - title: Checkout Steps
+                  url: /docs/scos/dev/features/checkout/multi-step-checkout/checkout-steps-.html
+                  include_versions:
+                    - '201903.0'
+                    - '201907.0'
+            - title: Define Payment & Shipment Methods
+              url: /docs/scos/dev/features/checkout/define-payment-.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+                - '201907.0'
+                - '202001.0'
+            - title: Checkout feature overview
+              nested:
+                - title: Multi-step Checkout
+                  url: /docs/scos/dev/features/checkout/checkout-feature-overview/multi-step-chec.html
+                  include_versions:
+                    - '202108.0'
+                - title: Order Thresholds
+                  url: /docs/scos/dev/features/checkout/checkout-feature-overview/order-threshold.html
+                  include_versions:
+                    - '202108.0'
+                - title: Multi-step checkout
+                  url: /docs/scos/dev/features/checkout/checkout-feature-overview/multi-step-chec.html
+                  include_versions:
+                    - '202009.0'
+                - title: Order thresholds
+                  url: /docs/scos/dev/features/checkout/checkout-feature-overview/order-threshold.html
+                  include_versions:
+                    - '202009.0'
+        - title: Customer Relationship Management (CRM)
+          nested:
+            - title: Password Management
+              url: /docs/scos/dev/features/customer-relationship-management-crm/password-manage.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+                - '201907.0'
+                - '202001.0'
+            - title: Customer Groups
+              nested:
+                - title: Customer Module Overview
+                  url: /docs/scos/dev/features/customer-relationship-management-crm/customer-groups/customer-module.html
+                  include_versions:
+                    - '201811.0'
+                    - '201903.0'
+                    - '201907.0'
+                    - '202001.0'
+                    - '202005.0'
+                - title: Customer Groups
+                  url: /docs/scos/dev/features/customer-relationship-management-crm/customer-groups/customer-groups.html
+                  include_versions:
+                    - '201811.0'
+                    - '201903.0'
+                    - '201907.0'
+                    - '202001.0'
+                    - '202005.0'
+            - title: Login & Registration Forms
+              url: /docs/scos/dev/features/customer-relationship-management-crm/login-registrat.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+                - '201907.0'
+                - '202001.0'
+                - '202005.0'
+            - title: Customer Accounts
+              url: /docs/scos/dev/features/customer-relationship-management-crm/customer-accoun.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+                - '201907.0'
+                - '202001.0'
+                - '202005.0'
+            - title: Customer Relationship Management (CRM)
+              url: /docs/scos/dev/features/customer-relationship-management-crm/crm.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+                - '201907.0'
+                - '202001.0'
+                - '202005.0'
+            - title: User and Rights Management
+              url: /docs/scos/dev/features/customer-relationship-management-crm/user-and-rights.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+                - '201907.0'
+                - '202001.0'
+                - '202005.0'
+        - title: Shopping  cart
+          nested:
+            - title: Cart Notes
+              nested:
+                - title: Cart Notes Feature Overview
+                  url: /docs/scos/dev/features/shopping-cart/cart-notes/cart-notes-over.html
+                  include_versions:
+                    - '201811.0'
+                    - '201903.0'
+                    - '201907.0'
+                    - '202001.0'
+                    - '202005.0'
+                - title: Cart Notes
+                  url: /docs/scos/dev/features/shopping-cart/cart-notes/cart-notes.html
+                  include_versions:
+                    - '201811.0'
+                    - '201903.0'
+                    - '201907.0'
+                    - '202001.0'
+                    - '202005.0'
+            - title: Unique URL per cart for easy sharing
+              nested:
+                - title: Unique URL per Cart for Easy Sharing Feature Overview
+                  url: /docs/scos/dev/features/shopping-cart/unique-url-per-cart-for-easy-sharing/unique-url-per-.html
+                  include_versions:
+                    - '201907.0'
+                    - '202001.0'
+                    - '202005.0'
+            - title: Shared Cart
+              nested:
+                - title: Shared Cart
+                  url: /docs/scos/dev/features/shopping-cart/shared-cart/shared-cart.html
+                  include_versions:
+                    - '201811.0'
+                    - '201903.0'
+                    - '201907.0'
+                    - '202001.0'
+                    - '202005.0'
+                - title: Shared Cart Feature Overview
+                  url: /docs/scos/dev/features/shopping-cart/shared-cart/shared-cart-ove.html
+                  include_versions:
+                    - '201811.0'
+                    - '201903.0'
+                    - '201907.0'
+                    - '202001.0'
+                    - '202005.0'
+            - title: Shopping Cart Widget
+              nested:
+                - title: Shopping Cart Widget Feature Overview
+                  url: /docs/scos/dev/features/shopping-cart/shopping-cart-widget/cart-widget-ove.html
+                  include_versions:
+                    - '201811.0'
+                    - '201903.0'
+                    - '201907.0'
+                    - '202001.0'
+                    - '202005.0'
+                - title: Shopping Cart Widget
+                  url: /docs/scos/dev/features/shopping-cart/shopping-cart-widget/cart-widget.html
+                  include_versions:
+                    - '201811.0'
+                    - '201903.0'
+                    - '201907.0'
+                    - '202001.0'
+                    - '202005.0'
+            - title: Cart Functionality and Calculations
+              nested:
+                - title: Cart Functionality
+                  url: /docs/scos/dev/features/shopping-cart/cart-functionality-and-calculations/cart-functional.html
+                  include_versions:
+                    - '201811.0'
+                    - '201903.0'
+                    - '201907.0'
+                    - '202001.0'
+                    - '202005.0'
+            - title: Calculation
+              nested:
+                - title: Calculation 3.0
+                  url: /docs/scos/dev/features/shopping-cart/calculation/calculation-3-0.html
+                  include_versions:
+                    - '201811.0'
+                    - '201903.0'
+                    - '201907.0'
+                    - '202001.0'
+                    - '202005.0'
+                - title: Calculation Data Structure
+                  url: /docs/scos/dev/features/shopping-cart/calculation/calculation-dat.html
+                  include_versions:
+                    - '201811.0'
+                    - '201903.0'
+                    - '201907.0'
+                    - '202001.0'
+                    - '202005.0'
+                - title: Calculator Plugins
+                  url: /docs/scos/dev/features/shopping-cart/calculation/calculator-plug.html
+                  include_versions:
+                    - '201811.0'
+                    - '201903.0'
+                    - '201907.0'
+                    - '202001.0'
+                    - '202005.0'
+            - title: Cart Rules and Discounts
+              url: /docs/scos/dev/features/shopping-cart/cart-rules-disc.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+                - '201907.0'
+                - '202001.0'
+            - title: Minimum Order Value
+              nested:
+                - title: Minimum Order Value Feature Overview
+                  url: /docs/scos/dev/features/shopping-cart/minimum-order-value/order-threshold.html
+                  include_versions:
+                    - '201903.0'
+                    - '201907.0'
+                    - '202001.0'
+                    - '202005.0'
+                - title: Minimum Order Value
+                  url: /docs/scos/dev/features/shopping-cart/minimum-order-value/order-threshold.html
+                  include_versions:
+                    - '201903.0'
+                    - '201907.0'
+            - title: Shopping Cart
+              url: /docs/scos/dev/features/shopping-cart/cart.html
+              include_versions:
+                - '201811.0'
+                - '201907.0'
+                - '202001.0'
+                - '202005.0'
+            - title: Multiple Carts Per User
+              nested:
+                - title: Multiple Carts per User Feature Overview
+                  url: /docs/scos/dev/features/shopping-cart/multiple-carts-per-user/multiple-carts-.html
+                  include_versions:
+                    - '201811.0'
+                    - '201903.0'
+                    - '201907.0'
+                    - '202001.0'
+                    - '202005.0'
+                - title: Multiple Carts Per User
+                  url: /docs/scos/dev/features/shopping-cart/multiple-carts-per-user/multiple-cart-p.html
+                  include_versions:
+                    - '201811.0'
+                    - '201903.0'
+                    - '201907.0'
+                    - '202001.0'
+                    - '202005.0'
+            - title: Quick Order
+              nested:
+                - title: Quick Order Feature Overview
+                  url: /docs/scos/dev/features/shopping-cart/quick-order/quick-order-ove.html
+                  include_versions:
+                    - '201811.0'
+                    - '201903.0'
+                    - '201907.0'
+                    - '202001.0'
+                    - '202005.0'
+                - title: Quick Order
+                  url: /docs/scos/dev/features/shopping-cart/quick-order/quick-order.html
+                  include_versions:
+                    - '201811.0'
+                    - '201903.0'
+                    - '201907.0'
+                    - '202001.0'
+                    - '202005.0'
+            - title: Shopping cart
+              url: /docs/scos/dev/features/shopping-cart/shopping-carts.html
+              include_versions:
+                - '201903.0'
+                - '202009.0'
+        - title: Mailing & Communication
+          nested:
+            - title: Comments
+              nested:
+                - title: Comments
+                  url: /docs/scos/dev/features/mailing-and-communication/comments/comments.html
+                  include_versions:
+                    - '201907.0'
+                    - '202001.0'
+                    - '202005.0'
+                - title: Comments Feature Overview
+                  url: /docs/scos/dev/features/mailing-and-communication/comments/comments-featur.html
+                  include_versions:
+                    - '201907.0'
+                    - '202001.0'
+                    - '202005.0'
+            - title: Back in Stock Notification
+              nested:
+                - title: Back in Stock Notification Feature Overview
+                  url: /docs/scos/dev/features/mailing-and-communication/back-in-stock-notification/back-in-stock-n.html
+                  include_versions:
+                    - '201903.0'
+                    - '202001.0'
+                    - '202005.0'
+                - title: Back in Stock Feature Overview
+                  url: /docs/scos/dev/features/mailing-and-communication/back-in-stock-notification/back-in-stock-n.html
+                  include_versions:
+                    - '201907.0'
+            - title: Mailing & Communication
+              url: /docs/scos/dev/features/mailing-and-communication/mailing-communi.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+                - '201907.0'
+                - '202001.0'
+                - '202005.0'
+            - title: Transactional E-Mail Management
+              url: /docs/scos/dev/features/mailing-and-communication/transactional-e.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+                - '201907.0'
+                - '202001.0'
+                - '202005.0'
+            - title: Newsletter Subscription
+              url: /docs/scos/dev/features/mailing-and-communication/newsletter-subs.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+                - '201907.0'
+                - '202001.0'
+                - '202005.0'
+        - title: Price
+          nested:
+            - title: Prices per Merchant Relation
+              nested:
+                - title: Prices per Merchant Relation Feature Overview
+                  url: /docs/scos/dev/features/price/prices-per-merchant-relation/price-per-merch.html
+                  include_versions:
+                    - '201811.0'
+                    - '201903.0'
+                    - '201907.0'
+                    - '202001.0'
+                    - '202005.0'
+            - title: Price Functionality
+              url: /docs/scos/dev/features/price/price-functiona.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+                - '201907.0'
+                - '202001.0'
+                - '202005.0'
+            - title: Price
+              url: /docs/scos/dev/features/price/price.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+                - '201907.0'
+                - '202001.0'
+                - '202005.0'
+            - title: Auto-Detect of Currency
+              url: /docs/scos/dev/features/price/auto-detect-cur.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+                - '201907.0'
+                - '202001.0'
+                - '202005.0'
+            - title: Money
+              url: /docs/scos/dev/features/price/money.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+                - '201907.0'
+                - '202001.0'
+                - '202005.0'
+            - title: Scheduled prices
+              nested:
+                - title: Scheduled Prices Feature Overview
+                  url: /docs/scos/dev/features/price/scheduled-prices/scheduled-price.html
+                  include_versions:
+                    - '201907.0'
+                    - '202001.0'
+                    - '202005.0'
+            - title: Net & Gross Prices
+              url: /docs/scos/dev/features/price/net-gross-price.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+                - '201907.0'
+                - '202001.0'
+                - '202005.0'
+            - title: Volume Prices
+              nested:
+                - title: Volume Prices Feature Overview
+                  url: /docs/scos/dev/features/price/volume-prices/volume-prices-o.html
+                  include_versions:
+                    - '201811.0'
+                    - '201903.0'
+                    - '201907.0'
+                    - '202001.0'
+                    - '202005.0'
+                - title: Volume Prices
+                  url: /docs/scos/dev/features/price/volume-prices/volume-prices.html
+                  include_versions:
+                    - '201811.0'
+                    - '201903.0'
+                    - '201907.0'
+                    - '202001.0'
+                    - '202005.0'
+        - title: Shopping List
+          nested:
+            - title: Printing a shopping list
+              nested:
+                - title: Printing a Shopping List Feature Overview
+                  url: /docs/scos/dev/features/shopping-list/printing-a-shopping-list/printing-shoppi.html
+                  include_versions:
+                    - '201811.0'
+                    - '201903.0'
+                    - '201907.0'
+                    - '202001.0'
+                    - '202005.0'
+                - title: Printing a shopping list feature overview
+                  url: /docs/scos/dev/features/shopping-list/printing-a-shopping-list/printing-shoppi.html
+                  include_versions:
+                    - '202009.0'
+            - title: Shopping List
+              url: /docs/scos/dev/features/shopping-list/shopping-list.html
+            - title: Shopping list notes
+              nested:
+                - title: Shopping List Notes
+                  url: /docs/scos/dev/features/shopping-list/shopping-list-notes/shopping-list-n.html
+                  include_versions:
+                    - '201811.0'
+                    - '201903.0'
+                    - '201907.0'
+                    - '202001.0'
+                    - '202005.0'
+                - title: Shopping list notes
+                  url: /docs/scos/dev/features/shopping-list/shopping-list-notes/shopping-list-n.html
+                  include_versions:
+                    - '202009.0'
+            - title: Shopping list widget
+              nested:
+                - title: Shopping List Widget
+                  url: /docs/scos/dev/features/shopping-list/shopping-list-widget/shopping-list-w.html
+                  include_versions:
+                    - '201811.0'
+                    - '201903.0'
+                    - '201907.0'
+                    - '202001.0'
+                    - '202005.0'
+                - title: Shopping list widget
+                  url: /docs/scos/dev/features/shopping-list/shopping-list-widget/shopping-list-w.html
+                  include_versions:
+                    - '202009.0'
+            - title: Multiple and shared shopping lists
+              nested:
+                - title: Multiple and Shared Shopping Lists Overview
+                  url: /docs/scos/dev/features/shopping-list/multiple-and-shared-shopping-lists/multiple-shared.html
+                  include_versions:
+                    - '201903.0'
+                    - '202001.0'
+                    - '202005.0'
+                - title: Multiple and Shared Shopping Lists overview
+                  url: /docs/scos/dev/features/shopping-list/multiple-and-shared-shopping-lists/multiple-shared.html
+                  include_versions:
+                    - '202009.0'
+                - title: Multiple and Shared Shopping Lists
+                  url: /docs/scos/dev/features/shopping-list/multiple-and-shared-shopping-lists/multiple-shared.html
+                  include_versions:
+                    - '201907.0'
+        - title: CMS
+          nested:
+            - title: CMS Page Drafts and Previews
+              url: /docs/scos/dev/features/cms/page-draft-prev.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+                - '201907.0'
+                - '202001.0'
+                - '202005.0'
+            - title: Content items
+              nested:
+                - title: Content Items Feature Overview
+                  url: /docs/scos/dev/features/cms/content-items/content-items-f.html
+                  include_versions:
+                    - '202001.0'
+                    - '202005.0'
+                - title: Content Item Types- Module Relations
+                  url: /docs/scos/dev/features/cms/content-items/content-item-ty.html
+                  include_versions:
+                    - '202001.0'
+                    - '202005.0'
+                - title: Content Items
+                  url: /docs/scos/dev/features/cms/content-items/content-items.html
+                  include_versions:
+                    - '201907.0'
+                    - '202001.0'
+                    - '202005.0'
+                - title: Content Items Types- Module Relations
+                  url: /docs/scos/dev/features/cms/content-items/content-items-t.html
+                  include_versions:
+                    - '201907.0'
+                - title: Content Items Overview
+                  url: /docs/scos/dev/features/cms/content-items/content-items-o.html
+                  include_versions:
+                    - '201907.0'
+            - title: Page Versions
+              url: /docs/scos/dev/features/cms/page-versions.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+                - '201907.0'
+                - '202001.0'
+                - '202005.0'
+            - title: Templates & slots
+              nested:
+                - title: Templates & Slots Feature Overview
+                  url: /docs/scos/dev/features/cms/templates-and-slots/templates-slots.html
+                  include_versions:
+                    - '202001.0'
+                    - '202005.0'
+            - title: CMS Page
+              nested:
+                - title: CMS Extension Points
+                  url: /docs/scos/dev/features/cms/cms-page/cms-extension-p.html
+                  include_versions:
+                    - '201811.0'
+                    - '201903.0'
+                    - '201907.0'
+                    - '202001.0'
+                    - '202005.0'
+                - title: Multi-store CMS Pages
+                  url: /docs/scos/dev/features/cms/cms-page/multi-store-cms.html
+                  include_versions:
+                    - '201903.0'
+                    - '201907.0'
+                    - '202001.0'
+                    - '202005.0'
+                - title: CMS Page
+                  url: /docs/scos/dev/features/cms/cms-page/cms-page.html
+                  include_versions:
+                    - '201811.0'
+                    - '201903.0'
+                    - '201907.0'
+                    - '202001.0'
+                    - '202005.0'
+            - title: Customizable Templates
+              url: /docs/scos/dev/features/cms/customizable-te.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+                - '201907.0'
+                - '202001.0'
+                - '202005.0'
+            - title: Multi-Store Content Translations
+              url: /docs/scos/dev/features/cms/multi-store-con.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+                - '201907.0'
+                - '202001.0'
+                - '202005.0'
+            - title: Publish to Live
+              url: /docs/scos/dev/features/cms/publish-to-live.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+                - '201907.0'
+                - '202001.0'
+                - '202005.0'
+            - title: CMS Block
+              nested:
+                - title: Multi-store CMS Block
+                  url: /docs/scos/dev/features/cms/cms-block/multi-store-cms.html
+                  include_versions:
+                    - '201811.0'
+                    - '201903.0'
+                    - '201907.0'
+                    - '202001.0'
+                    - '202005.0'
+                - title: CMS Block
+                  url: /docs/scos/dev/features/cms/cms-block/cms-block.html
+                  include_versions:
+                    - '201811.0'
+                    - '201903.0'
+                    - '201907.0'
+                    - '202001.0'
+                    - '202005.0'
+                - title: Product and Category CMS Blocks
+                  url: /docs/scos/dev/features/cms/cms-block/category-block.html
+                  include_versions:
+                    - '201811.0'
+                    - '201903.0'
+                    - '201907.0'
+                    - '202001.0'
+                    - '202005.0'
+            - title: Time Restricted Content Page Publishing
+              url: /docs/scos/dev/features/cms/time-restricted.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+                - '201907.0'
+                - '202001.0'
+                - '202005.0'
+            - title: WYSIWYG Editor
+              url: /docs/scos/dev/features/cms/wysiwyg-editor.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+                - '201907.0'
+                - '202001.0'
+                - '202005.0'
+            - title: CMS
+              url: /docs/scos/dev/features/cms/cms.html
+              include_versions:
+                - '201903.0'
+            - title: Content Search Widget
+              url: /docs/scos/dev/features/cms/content-search-.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+                - '201907.0'
+                - '202001.0'
+                - '202005.0'
+            - title: CMS feature overview
+              nested:
+                - title: Email as a CMS block overview
+                  url: /docs/scos/dev/features/cms/cms-feature-overview/email-as-a-cms-.html
+                  include_versions:
+                    - '202108.0'
+                - title: Templates and Slots overview
+                  url: /docs/scos/dev/features/cms/cms-feature-overview/templates-and-s.html
+                  include_versions:
+                    - '202108.0'
+                - title: CMS extension points- reference information
+                  url: /docs/scos/dev/features/cms/cms-feature-overview/reference-infor.html
+                  include_versions:
+                    - '202009.0'
+                    - '202108.0'
+                - title: CMS Pages overview
+                  url: /docs/scos/dev/features/cms/cms-feature-overview/cms-pages-overv.html
+                  include_versions:
+                    - '202108.0'
+                - title: CMS blocks overview
+                  url: /docs/scos/dev/features/cms/cms-feature-overview/cms-blocks-over.html
+                  include_versions:
+                    - '202108.0'
+                - title: CMS pages in search results overview
+                  url: /docs/scos/dev/features/cms/cms-feature-overview/cms-pages-in-se.html
+                  include_versions:
+                    - '202108.0'
+                - title: Email as a CMS block
+                  url: /docs/scos/dev/features/cms/cms-feature-overview/email-as-a-cms-.html
+                  include_versions:
+                    - '202009.0'
+                - title: Templates & slots
+                  nested:
+                    - title: Templates & slots feature overview
+                      url: /docs/scos/dev/features/cms/cms-feature-overview/templates-and-slots/templates-slots.html
+                      include_versions:
+                        - '202009.0'
+                - title: Templates and slots
+                  url: /docs/scos/dev/features/cms/cms-feature-overview/templates-and-s.html
+                  include_versions:
+                    - '202009.0'
+                - title: CMS pages in search results
+                  url: /docs/scos/dev/features/cms/cms-feature-overview/cms-pages-in-se.html
+                  include_versions:
+                    - '202009.0'
+                - title: CMS page
+                  url: /docs/scos/dev/features/cms/cms-feature-overview/cms-page.html
+                  include_versions:
+                    - '202009.0'
+                - title: WYSIWYG editor
+                  url: /docs/scos/dev/features/cms/cms-feature-overview/wysiwyg-editor.html
+                  include_versions:
+                    - '202009.0'
+                - title: CMS block
+                  url: /docs/scos/dev/features/cms/cms-feature-overview/cms-block.html
+                  include_versions:
+                    - '202009.0'
+            - title: Content Item Widgets
+              nested:
+                - title: Content Items Widgets
+                  url: /docs/scos/dev/features/cms/content-item-widgets/content-item-wi.html
+                  include_versions:
+                    - '201907.0'
+                - title: Content Items Widgets Overview
+                  url: /docs/scos/dev/features/cms/content-item-widgets/content-items-w.html
+                  include_versions:
+                    - '201907.0'
+            - title: CMS Widget
+              nested:
+                - title: CMS Widget
+                  url: /docs/scos/dev/features/cms/cms-widget/cms-widget.html
+                  include_versions:
+                    - '201903.0'
+                - title: CMS Widget Overview
+                  url: /docs/scos/dev/features/cms/cms-widget/cms-widget-over.html
+                  include_versions:
+                    - '201903.0'
+        - title: SDK
+          nested:
+            - title: Zed API
+              nested:
+                - title: CRUD Functionality - Zed API
+                  url: /docs/scos/dev/features/sdk/zed-api/zed-api-crud-fu.html
+                  include_versions:
+                    - '201811.0'
+                    - '201903.0'
+                    - '201907.0'
+                    - '202001.0'
+                    - '202005.0'
+                - title: Processor Stack - Zed API
+                  url: /docs/scos/dev/features/sdk/zed-api/zed-api-process.html
+                  include_versions:
+                    - '201811.0'
+                    - '201903.0'
+                    - '201907.0'
+                    - '202001.0'
+                    - '202005.0'
+                - title: Zed API Configuration
+                  url: /docs/scos/dev/features/sdk/zed-api/zed-api-config.html
+                  include_versions:
+                    - '201811.0'
+                    - '201903.0'
+                    - '201907.0'
+                    - '202001.0'
+                    - '202005.0'
+                - title: Project Implementation - Zed API
+                  url: /docs/scos/dev/features/sdk/zed-api/zed-api-project.html
+                  include_versions:
+                    - '201811.0'
+                    - '201903.0'
+                    - '201907.0'
+                    - '202001.0'
+                    - '202005.0'
+                - title: Zed API Resources
+                  url: /docs/scos/dev/features/sdk/zed-api/zed-api-resourc.html
+                  include_versions:
+                    - '201811.0'
+                    - '201903.0'
+                    - '201907.0'
+                    - '202001.0'
+                    - '202005.0'
+                - title: Zed API (BETA)
+                  url: /docs/scos/dev/features/sdk/zed-api/zed-api.html
+                  include_versions:
+                    - '201811.0'
+            - title: Cronjob Scheduling
+              url: /docs/scos/dev/features/sdk/cronjob-schedul.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+                - '201907.0'
+                - '202001.0'
+                - '202005.0'
+            - title: Twig and TwigExtension
+              url: /docs/scos/dev/features/sdk/twig-and-twig-e.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+                - '201907.0'
+                - '202001.0'
+                - '202005.0'
+            - title: 'Development Virtual Machine, Docker Containers & Console'
+              url: /docs/scos/dev/features/sdk/devvm.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+                - '201907.0'
+                - '202001.0'
+                - '202005.0'
+            - title: CSS Class Customization
+              url: /docs/scos/dev/features/sdk/css-class-custo.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+                - '201907.0'
+                - '202001.0'
+                - '202005.0'
+            - title: Importer
+              url: /docs/scos/dev/features/sdk/importer.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+                - '201907.0'
+                - '202001.0'
+            - title: Development tools
+              nested:
+                - title: Tooling config file
+                  url: /docs/scos/dev/features/sdk/development-tools/tooling-config-.html
+                  include_versions:
+                    - '201903.0'
+                    - '201907.0'
+                    - '202001.0'
+                    - '202005.0'
+                - title: Code Sniffer
+                  url: /docs/scos/dev/features/sdk/development-tools/code-sniffer.html
+                  include_versions:
+                    - '201811.0'
+                    - '201903.0'
+                    - '201907.0'
+                    - '202001.0'
+                    - '202005.0'
+                - title: Development Tools
+                  url: /docs/scos/dev/features/sdk/development-tools/development-too.html
+                  include_versions:
+                    - '201811.0'
+                    - '201903.0'
+                    - '201907.0'
+                    - '202001.0'
+                    - '202005.0'
+                - title: PHPStan
+                  url: /docs/scos/dev/features/sdk/development-tools/phpstan.html
+                  include_versions:
+                    - '201903.0'
+                    - '201907.0'
+                    - '202001.0'
+                    - '202005.0'
+                - title: Architecture Sniffer
+                  url: /docs/scos/dev/features/sdk/development-tools/architecture-sn.html
+                  include_versions:
+                    - '201811.0'
+                    - '201903.0'
+                    - '201907.0'
+                    - '202001.0'
+                    - '202005.0'
+            - title: Spryk Code Generator
+              url: /docs/scos/dev/features/sdk/spryk.html
+              include_versions:
+                - '201903.0'
+                - '201907.0'
+                - '202001.0'
+                - '202005.0'
+            - title: Development
+              url: /docs/scos/dev/features/sdk/development.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+                - '201907.0'
+                - '202001.0'
+                - '202005.0'
+            - title: Code Generator
+              url: /docs/scos/dev/features/sdk/code-generator.html
+              include_versions:
+                - '201811.0'
+            - title: Data Export
+              url: /docs/scos/dev/features/sdk/data-export.html
+              include_versions:
+                - '202005.0'
+            - title: Data Import
+              url: /docs/scos/dev/features/sdk/importer.html
+              include_versions:
+                - '202005.0'
+        - title: Company Account Management
+          nested:
+            - title: Company Account Management
+              url: /docs/scos/dev/features/company-account-management/company-account.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+                - '201907.0'
+                - '202001.0'
+                - '202005.0'
+            - title: Business Unit Management
+              nested:
+                - title: Business Unit Management
+                  url: /docs/scos/dev/features/company-account-management/business-unit-management/business-unit-m.html
+                  include_versions:
+                    - '201811.0'
+                    - '201903.0'
+                    - '201907.0'
+                    - '202001.0'
+                    - '202005.0'
+            - title: Hide Content from Logged out Users
+              nested:
+                - title: Hide Content from Logged out Users Overview
+                  url: /docs/scos/dev/features/company-account-management/hide-content-from-logged-out-users/hide-content-fr.html
+                  include_versions:
+                    - '201811.0'
+                    - '201903.0'
+                    - '201907.0'
+                    - '202001.0'
+                    - '202005.0'
+            - title: Company Account Overview
+              nested:
+                - title: Company Account Overview
+                  url: /docs/scos/dev/features/company-account-management/company-account-overview/company-account.html
+                  include_versions:
+                    - '201811.0'
+                    - '201903.0'
+                    - '201907.0'
+                    - '202001.0'
+                    - '202005.0'
+            - title: Company User  Roles and Permissions
+              nested:
+                - title: Company User Roles and Permissions
+                  url: /docs/scos/dev/features/company-account-management/company-user-roles-and-permissions/company-user-ro.html
+                  include_versions:
+                    - '201811.0'
+                    - '201903.0'
+                    - '201907.0'
+                    - '202001.0'
+                    - '202005.0'
+                - title: Company User Roles and Permissions Feature Overview
+                  url: /docs/scos/dev/features/company-account-management/company-user-roles-and-permissions/company-roles-p.html
+                  include_versions:
+                    - '201907.0'
+                    - '202001.0'
+            - title: Agent Assist
+              nested:
+                - title: Agent Assist
+                  url: /docs/scos/dev/features/company-account-management/agent-assist/agent-assist.html
+                  include_versions:
+                    - '201903.0'
+                    - '201907.0'
+                    - '202001.0'
+                    - '202005.0'
+                - title: Agent Assist Feature Overview
+                  url: /docs/scos/dev/features/company-account-management/agent-assist/agent-assist-ov.html
+                  include_versions:
+                    - '201903.0'
+                    - '201907.0'
+                    - '202001.0'
+                    - '202005.0'
+            - title: Merchants and merchant relations
+              nested:
+                - title: Merchants and Merchant Relations Feature Overview
+                  url: /docs/scos/dev/features/company-account-management/merchants-and-merchant-relations/merchants-and-m.html
+                  include_versions:
+                    - '201903.0'
+                    - '201907.0'
+                    - '202001.0'
+                    - '202005.0'
+            - title: Product Restrictions from Merchant to Buyer
+              nested:
+                - title: Product Restrictions from Merchant to Buyer
+                  url: /docs/scos/dev/features/company-account-management/product-restrictions-from-merchant-to-buyer/product-restric.html
+                  include_versions:
+                    - '201903.0'
+                    - '201907.0'
+                    - '202001.0'
+                    - '202005.0'
+                - title: Restricted Products Behavior
+                  url: /docs/scos/dev/features/company-account-management/product-restrictions-from-merchant-to-buyer/restricted-prod.html
+                  include_versions:
+                    - '201903.0'
+                    - '201907.0'
+                    - '202001.0'
+                    - '202005.0'
+            - title: Business On Behalf
+              nested:
+                - title: Business On Behalf Feature Overview
+                  url: /docs/scos/dev/features/company-account-management/business-on-behalf/business-on-beh.html
+                  include_versions:
+                    - '201903.0'
+                    - '201907.0'
+                    - '202001.0'
+                    - '202005.0'
+        - title: Product information management
+          nested:
+            - title: Product Attributes
+              url: /docs/scos/dev/features/product-information-management/product-attribu.html
+              include_versions:
+                - '202001.0'
+                - '202005.0'
+            - title: Product
+              url: /docs/scos/dev/features/product-information-management/product.html
+              include_versions:
+                - '202001.0'
+                - '202005.0'
+            - title: Discontinued Products
+              nested:
+                - title: Discontinued Products Feature Overview
+                  url: /docs/scos/dev/features/product-information-management/discontinued-products/discontinued-pr.html
+                  include_versions:
+                    - '202001.0'
+                    - '202005.0'
+            - title: Product Bundles
+              url: /docs/scos/dev/features/product-information-management/product-bundle.html
+              include_versions:
+                - '202001.0'
+                - '202005.0'
+            - title: Product Abstraction
+              url: /docs/scos/dev/features/product-information-management/product-abstrac.html
+              include_versions:
+                - '202001.0'
+                - '202005.0'
+            - title: Alternative Products
+              nested:
+                - title: Alternative Products Feature Overview
+                  url: /docs/scos/dev/features/product-information-management/alternative-products/alternative-pro.html
+                  include_versions:
+                    - '202001.0'
+                    - '202005.0'
+            - title: Timed Product Availability Feature Overview
+              nested:
+                - title: Timed Product Availability Feature Overview
+                  url: /docs/scos/dev/features/product-information-management/timed-product-availability-feature-overview/product-ttl-fea.html
+                  include_versions:
+                    - '202001.0'
+                    - '202005.0'
+                - title: Timed Product Availability
+                  url: /docs/scos/dev/features/product-information-management/timed-product-availability-feature-overview/product-ttl.html
+                  include_versions:
+                    - '202001.0'
+                    - '202005.0'
+            - title: Product Label
+              url: /docs/scos/dev/features/product-information-management/product-label.html
+              include_versions:
+                - '202001.0'
+                - '202005.0'
+            - title: Super Attributes
+              url: /docs/scos/dev/features/product-information-management/super-attribute.html
+              include_versions:
+                - '202001.0'
+                - '202005.0'
+            - title: Product Group
+              url: /docs/scos/dev/features/product-information-management/product-group.html
+              include_versions:
+                - '202001.0'
+            - title: Product Reviews
+              url: /docs/scos/dev/features/product-information-management/product-reviews.html
+              include_versions:
+                - '202001.0'
+                - '202005.0'
+            - title: Dynamic Product Labels
+              url: /docs/scos/dev/features/product-information-management/dynamic-product.html
+              include_versions:
+                - '202001.0'
+                - '202005.0'
+            - title: New Products
+              url: /docs/scos/dev/features/product-information-management/new-products.html
+              include_versions:
+                - '202001.0'
+                - '202005.0'
+            - title: Barcode Generator
+              nested:
+                - title: Barcode Generator Feature Overview
+                  url: /docs/scos/dev/features/product-information-management/barcode-generator/barcode-generat.html
+                  include_versions:
+                    - '202001.0'
+                    - '202005.0'
+            - title: Product Quantity Restrictions
+              nested:
+                - title: Product Quantity Restrictions
+                  url: /docs/scos/dev/features/product-information-management/product-quantity-restrictions/product-quantit.html
+                  include_versions:
+                    - '202001.0'
+                    - '202005.0'
+            - title: Configurable Bundle
+              nested:
+                - title: Configurable Bundle Feature Overview
+                  url: /docs/scos/dev/features/product-information-management/configurable-bundle/configurable-bu.html
+                  include_versions:
+                    - '202001.0'
+                    - '202005.0'
+            - title: Product relations
+              nested:
+                - title: Product Relations Feature Overview
+                  url: /docs/scos/dev/features/product-information-management/product-relations/product-relatio.html
+                  include_versions:
+                    - '202001.0'
+                    - '202005.0'
+            - title: Product Set
+              url: /docs/scos/dev/features/product-information-management/product-set.html
+              include_versions:
+                - '202001.0'
+                - '202005.0'
+            - title: Feature Configuration - Product Reviews
+              url: /docs/scos/dev/features/product-information-management/product-review-.html
+              include_versions:
+                - '202001.0'
+                - '202005.0'
+            - title: Product Information Management
+              url: /docs/scos/dev/features/product-information-management/product-informa.html
+              include_versions:
+                - '202001.0'
+                - '202005.0'
+                - '202009.0'
+            - title: Product options
+              nested:
+                - title: Product Options
+                  url: /docs/scos/dev/features/product-information-management/product-options/product-options.html
+                  include_versions:
+                    - '202001.0'
+                    - '202005.0'
+        - title: Promotions & Discounts
+          nested:
+            - title: Discount Module Overview
+              url: /docs/scos/dev/features/promotions-and-discounts/discount-module.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+                - '201907.0'
+                - '202001.0'
+                - '202005.0'
+            - title: Extending the Discount Module
+              url: /docs/scos/dev/features/promotions-and-discounts/extending-the-d.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+                - '201907.0'
+                - '202001.0'
+                - '202005.0'
+            - title: Discount
+              nested:
+                - title: Discount
+                  url: /docs/scos/dev/features/promotions-and-discounts/discount/discount.html
+                  include_versions:
+                    - '201811.0'
+                    - '201903.0'
+                    - '201907.0'
+                    - '202001.0'
+                    - '202005.0'
+                - title: Discount Feature Overview
+                  url: /docs/scos/dev/features/promotions-and-discounts/discount/discount-featur.html
+                  include_versions:
+                    - '201903.0'
+                    - '201907.0'
+                    - '202001.0'
+                    - '202005.0'
+            - title: Promotions and Discounts
+              url: /docs/scos/dev/features/promotions-and-discounts/promotions-disc.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+                - '201907.0'
+                - '202001.0'
+                - '202005.0'
+            - title: Promotions & Discounts feature overview
+              url: /docs/scos/dev/features/promotions-and-discounts/promotions-disc.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+        - title: Media Management
+          nested:
+            - title: Image Hosting
+              url: /docs/scos/dev/features/media-management/image-hosting.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+                - '201907.0'
+                - '202001.0'
+                - '202005.0'
+            - title: Media Management
+              url: /docs/scos/dev/features/media-management/media-managemen.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+                - '201907.0'
+                - '202001.0'
+                - '202005.0'
+            - title: Video Embedding
+              url: /docs/scos/dev/features/media-management/video-embedding.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+                - '201907.0'
+                - '202001.0'
+                - '202005.0'
+            - title: Asset Management
+              url: /docs/scos/dev/features/media-management/asset-managemen.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+                - '201907.0'
+            - title: File Uploader
+              nested:
+                - title: File Uploader Feature Overview
+                  url: /docs/scos/dev/features/media-management/file-uploader/file-uploader-f.html
+                  include_versions:
+                    - '201811.0'
+                    - '201903.0'
+                    - '201907.0'
+                    - '202001.0'
+                    - '202005.0'
+                - title: File Uploader
+                  url: /docs/scos/dev/features/media-management/file-uploader/file-uploader.html
+                  include_versions:
+                    - '201811.0'
+                    - '201903.0'
+                    - '201907.0'
+                    - '202001.0'
+                    - '202005.0'
+            - title: Product Image Management
+              url: /docs/scos/dev/features/media-management/product-image-m.html
+              include_versions:
+                - '201907.0'
+                - '202001.0'
+                - '202005.0'
+        - title: Technology partner integrations
+          nested:
+            - title: Punch out
+              nested:
+                - title: Punch Out Feature Overview
+                  url: /docs/scos/dev/features/technology-partner-integrations/punch-out/punchout-featur.html
+                  include_versions:
+                    - '201907.0'
+                    - '202001.0'
+                    - '202005.0'
+                - title: Punch Out
+                  url: /docs/scos/dev/features/technology-partner-integrations/punch-out/punchout.html
+                  include_versions:
+                    - '201907.0'
+                    - '202001.0'
+                    - '202005.0'
+            - title: Technology Partner Integrations
+              url: /docs/scos/dev/features/technology-partner-integrations/technology-part.html
+              include_versions:
+                - '201903.0'
+                - '201907.0'
+                - '202001.0'
+                - '202005.0'
+            - title: Punchout
+              nested:
+                - title: Punchout feature overview
+                  url: /docs/scos/dev/features/technology-partner-integrations/punchout/punchout-featur.html
+                  include_versions:
+                    - '202009.0'
+                - title: Punchout
+                  url: /docs/scos/dev/features/technology-partner-integrations/punchout/punchout.html
+                  include_versions:
+                    - '202009.0'
+            - title: Integrating technology partners
+              url: /docs/scos/dev/features/technology-partner-integrations/integrating-tec.html
+              include_versions:
+                - '202009.0'
+        - title: Cross-sell and Up-sell
+          nested:
+            - title: Cross-Selling
+              url: /docs/scos/dev/features/cross-sell-and-up-sell/cross-sell.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+                - '201907.0'
+                - '202001.0'
+            - title: Upselling
+              url: /docs/scos/dev/features/cross-sell-and-up-sell/upsell.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+                - '201907.0'
+                - '202001.0'
+            - title: Cross-sell and Up-sell
+              url: /docs/scos/dev/features/cross-sell-and-up-sell/cross-sell-upse.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+                - '201907.0'
+                - '202001.0'
+                - '202005.0'
+            - title: Product Relations
+              url: /docs/scos/dev/features/cross-sell-and-up-sell/product-relatio.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+                - '201907.0'
+                - '202001.0'
+        - title: Shipment
+          nested:
+            - title: Carrier Companies and Delivery Methods
+              url: /docs/scos/dev/features/shipment/shipment-carrie.html
+              include_versions:
+                - '202001.0'
+            - title: Shipment Method Plugins
+              url: /docs/scos/dev/features/shipment/shipment-method.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+                - '201907.0'
+                - '202001.0'
+            - title: Shipment
+              url: /docs/scos/dev/features/shipment/shipment.html
+              include_versions:
+                - '201903.0'
+            - title: Shipment Calculation Rules
+              url: /docs/scos/dev/features/shipment/shipment-calcul.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+                - '201907.0'
+                - '202001.0'
+            - title: Multiple Currencies for Shipments
+              url: /docs/scos/dev/features/shipment/multiple-curren.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+                - '201907.0'
+                - '202001.0'
+            - title: Shipment Overview
+              url: /docs/scos/dev/features/shipment/shipment-overvi.html
+              include_versions:
+                - '201903.0'
+                - '201907.0'
+                - '202001.0'
+            - title: Shipment Carriers and Methods
+              url: /docs/scos/dev/features/shipment/shipment-carrie.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+                - '201907.0'
+            - title: Shipment Module Overview
+              url: /docs/scos/dev/features/shipment/shipment-module.html
+              include_versions:
+                - '201811.0'
+            - title: References
+              nested:
+                - title: Reference information- Shipment method plugins
+                  url: /docs/scos/dev/features/shipment/references/reference-infor.html
+                  include_versions:
+                    - '202108.0'
+            - title: Shipment feature overview
+              url: /docs/scos/dev/features/shipment/shipment-featur.html
+              include_versions:
+                - '202108.0'
+        - title: SEO
+          nested:
+            - title: URL Redirects
+              url: /docs/scos/dev/features/seo/url-redirects.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+                - '201907.0'
+                - '202001.0'
+                - '202005.0'
+            - title: Friendly URLs
+              url: /docs/scos/dev/features/seo/friendly-urls.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+                - '201907.0'
+                - '202001.0'
+                - '202005.0'
+            - title: Landing Pages
+              url: /docs/scos/dev/features/seo/landing-pages.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+                - '201907.0'
+                - '202001.0'
+                - '202005.0'
+            - title: SEO
+              url: /docs/scos/dev/features/seo/seo.html
+            - title: Meta Tags
+              url: /docs/scos/dev/features/seo/meta-tags.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+                - '201907.0'
+                - '202001.0'
+                - '202005.0'
+        - title: Back Office
+          nested:
+            - title: Data Protection
+              url: /docs/scos/dev/features/back-office/data-protection.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+                - '201907.0'
+                - '202001.0'
+                - '202005.0'
+            - title: Permission & ACL Management
+              url: /docs/scos/dev/features/back-office/permission-acl-.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+                - '201907.0'
+                - '202001.0'
+                - '202005.0'
+            - title: Back Office Translations
+              nested:
+                - title: Back Office Translations Feature Overview
+                  url: /docs/scos/dev/features/back-office/back-office-translations/back-office-tra.html
+                  include_versions:
+                    - '201903.0'
+                    - '201907.0'
+                    - '202001.0'
+                    - '202005.0'
+            - title: Customer Management
+              url: /docs/scos/dev/features/back-office/customer-manage.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+                - '201907.0'
+                - '202001.0'
+                - '202005.0'
+            - title: Back Office Management
+              url: /docs/scos/dev/features/back-office/back-office-man.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+                - '201907.0'
+                - '202001.0'
+                - '202005.0'
+            - title: Back Office
+              url: /docs/scos/dev/features/back-office/back-office.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+                - '201907.0'
+                - '202001.0'
+                - '202005.0'
+        - title: Multi-channel
+          nested:
+            - title: Multiple Touchpoints Integration
+              url: /docs/scos/dev/features/multi-channel/multiple-touchp.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+                - '201907.0'
+                - '202001.0'
+                - '202005.0'
+            - title: Responsive Design
+              url: /docs/scos/dev/features/multi-channel/responsive-desi.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+                - '201907.0'
+                - '202001.0'
+                - '202005.0'
+            - title: Multi-Channel
+              url: /docs/scos/dev/features/multi-channel/multi-channel.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+                - '201907.0'
+                - '202001.0'
+                - '202005.0'
+            - title: Multi-theme
+              nested:
+                - title: Multi-Theme
+                  url: /docs/scos/dev/features/multi-channel/multi-theme/multi-theme-201.html
+                  include_versions:
+                    - '201907.0'
+                    - '202001.0'
+                    - '202005.0'
+                - title: Multi-Theme Feature Overview
+                  url: /docs/scos/dev/features/multi-channel/multi-theme/multi-theme-fea.html
+                  include_versions:
+                    - '201907.0'
+                    - '202001.0'
+                    - '202005.0'
+                - title: Multi-theme feature overview
+                  url: /docs/scos/dev/features/multi-channel/multi-theme/multi-theme-fea.html
+                  include_versions:
+                    - '202009.0'
+                    - '202108.0'
+                - title: Multi-theme
+                  url: /docs/scos/dev/features/multi-channel/multi-theme/multi-theme.html
+                  include_versions:
+                    - '202009.0'
+                    - '202108.0'
+            - title: Multi-channel
+              url: /docs/scos/dev/features/multi-channel/multi-channel.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+        - title: Search and filter
+          nested:
+            - title: Search
+              url: /docs/scos/dev/features/search-and-filter/search.html
+            - title: Filters and Search by Category
+              url: /docs/scos/dev/features/search-and-filter/filter-search-b.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+                - '201907.0'
+                - '202001.0'
+                - '202005.0'
+            - title: Multi-Language Search
+              url: /docs/scos/dev/features/search-and-filter/multi-language-.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+                - '201907.0'
+                - '202001.0'
+                - '202005.0'
+            - title: Search Preferences
+              url: /docs/scos/dev/features/search-and-filter/search-preferen.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+                - '201907.0'
+                - '202001.0'
+                - '202005.0'
+            - title: Standard Filters
+              url: /docs/scos/dev/features/search-and-filter/standard-filter.html
+              include_versions:
+                - '202001.0'
+                - '202005.0'
+            - title: Dynamic Filters and Facets
+              url: /docs/scos/dev/features/search-and-filter/dynamic-filter-.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+                - '201907.0'
+                - '202001.0'
+                - '202005.0'
+            - title: Textual Search
+              url: /docs/scos/dev/features/search-and-filter/textual-search.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+                - '201907.0'
+                - '202001.0'
+                - '202005.0'
+            - title: CMS Pages in Search Results
+              url: /docs/scos/dev/features/search-and-filter/cms-pages-in-se.html
+              include_versions:
+                - '201903.0'
+                - '201907.0'
+                - '202001.0'
+                - '202005.0'
+            - title: Search widget for concrete products
+              nested:
+                - title: Search 4.0
+                  url: /docs/scos/dev/features/search-and-filter/search-widget-for-concrete-products/search-40.html
+                  include_versions:
+                    - '201903.0'
+                    - '201907.0'
+                    - '202001.0'
+                    - '202005.0'
+                    - '202009.0'
+                - title: Configure Search Features
+                  url: /docs/scos/dev/features/search-and-filter/search-widget-for-concrete-products/configure-searc.html
+                  include_versions:
+                    - '201903.0'
+                    - '201907.0'
+                    - '202001.0'
+                    - '202005.0'
+                    - '202009.0'
+                - title: Dynamic Filters Functionality
+                  url: /docs/scos/dev/features/search-and-filter/search-widget-for-concrete-products/dynamic-filters.html
+                  include_versions:
+                    - '201903.0'
+                    - '201907.0'
+                    - '202001.0'
+                    - '202005.0'
+                    - '202009.0'
+                - title: Search 3.0
+                  url: /docs/scos/dev/features/search-and-filter/search-widget-for-concrete-products/search-30.html
+                  include_versions:
+                    - '201903.0'
+                    - '201907.0'
+                    - '202001.0'
+                    - '202005.0'
+                    - '202009.0'
+                - title: Search Widget for Concrete Products
+                  url: /docs/scos/dev/features/search-and-filter/search-widget-for-concrete-products/search-widget-f.html
+                  include_versions:
+                    - '201903.0'
+                    - '201907.0'
+                    - '202001.0'
+                    - '202005.0'
+                - title: Multicurrency Search
+                  url: /docs/scos/dev/features/search-and-filter/search-widget-for-concrete-products/multicurrency-s.html
+                  include_versions:
+                    - '201903.0'
+                    - '201907.0'
+                    - '202001.0'
+                    - '202005.0'
+                    - '202009.0'
+                - title: Search Query
+                  url: /docs/scos/dev/features/search-and-filter/search-widget-for-concrete-products/search-query.html
+                  include_versions:
+                    - '201903.0'
+                    - '201907.0'
+                    - '202001.0'
+                    - '202005.0'
+                    - '202009.0'
+                - title: Configure Elasticsearch
+                  url: /docs/scos/dev/features/search-and-filter/search-widget-for-concrete-products/configure-elast.html
+                  include_versions:
+                    - '201903.0'
+                    - '201907.0'
+                    - '202001.0'
+                    - '202005.0'
+                    - '202009.0'
+                - title: Search widget for concrete products
+                  url: /docs/scos/dev/features/search-and-filter/search-widget-for-concrete-products/search-widget-f.html
+                  include_versions:
+                    - '202009.0'
+            - title: Search and Filter
+              url: /docs/scos/dev/features/search-and-filter/search-filter.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+                - '201907.0'
+                - '202001.0'
+                - '202005.0'
+            - title: Full-Site Search
+              url: /docs/scos/dev/features/search-and-filter/full-site-searc.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+                - '201907.0'
+                - '202001.0'
+                - '202005.0'
+            - title: 'Standard Filters (Size, Type, Color, Etc...)'
+              url: /docs/scos/dev/features/search-and-filter/standard-filter.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+                - '201907.0'
+            - title: Standard filters
+              url: /docs/scos/dev/features/search-and-filter/standard-filter.html
+              include_versions:
+                - '202009.0'
+            - title: Category filters
+              url: /docs/scos/dev/features/search-and-filter/category-filter.html
+              include_versions:
+                - '202009.0'
+            - title: Search and filter
+              url: /docs/scos/dev/features/search-and-filter/search-filter.html
+              include_versions:
+                - '202009.0'
+        - title: Workflow & Process Management
+          nested:
+            - title: Approval process
+              nested:
+                - title: Approval Process Feature Overview
+                  url: /docs/scos/dev/features/workflow-and-process-management/approval-process/approval-proces.html
+                  include_versions:
+                    - '201903.0'
+                    - '201907.0'
+                    - '202001.0'
+                    - '202005.0'
+            - title: Vault for Tokens
+              nested:
+                - title: Vault for Tokens
+                  url: /docs/scos/dev/features/workflow-and-process-management/vault-for-tokens/vault-for-token.html
+                  include_versions:
+                    - '201907.0'
+                    - '202001.0'
+                    - '202005.0'
+            - title: Quotation Process & RFQ
+              nested:
+                - title: Quotation Process & RFQ Feature Overview
+                  url: /docs/scos/dev/features/workflow-and-process-management/quotation-process-and-rfq/quotation-proce.html
+                  include_versions:
+                    - '201907.0'
+                    - '202001.0'
+                    - '202005.0'
+            - title: Customer Login by Token
+              nested:
+                - title: Customer Login by Token
+                  url: /docs/scos/dev/features/workflow-and-process-management/customer-login-by-token/customer-login-.html
+                  include_versions:
+                    - '201907.0'
+                    - '202001.0'
+                    - '202005.0'
+            - title: Workflow & Process Management
+              url: /docs/scos/dev/features/workflow-and-process-management/workflow-proces.html
+              include_versions:
+                - '201903.0'
+                - '201907.0'
+                - '202001.0'
+                - '202005.0'
+        - title: Wishlist
+          nested:
+            - title: Multiple Wishlists
+              url: /docs/scos/dev/features/wishlist/multiple-wishli.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+                - '201907.0'
+                - '202001.0'
+                - '202005.0'
+            - title: Convert Wishlist to Cart
+              url: /docs/scos/dev/features/wishlist/convert-wishlis.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+                - '201907.0'
+                - '202001.0'
+                - '202005.0'
+            - title: Wishlist Schema
+              url: /docs/scos/dev/features/wishlist/wishlist-schema.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+                - '201907.0'
+                - '202001.0'
+                - '202005.0'
+            - title: Wishlist Items Management
+              url: /docs/scos/dev/features/wishlist/wishlist-items-.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+                - '201907.0'
+                - '202001.0'
+                - '202005.0'
+            - title: Wishlist Management
+              url: /docs/scos/dev/features/wishlist/wishlist-manage.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+                - '201907.0'
+                - '202001.0'
+                - '202005.0'
+            - title: Named Wishlists
+              url: /docs/scos/dev/features/wishlist/named-wishlists.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+                - '201907.0'
+                - '202001.0'
+                - '202005.0'
+            - title: Wishlist
+              url: /docs/scos/dev/features/wishlist/wishlist.html
+              include_versions:
+                - '201903.0'
+            - title: Wishlist feature overview
+              url: /docs/scos/dev/features/wishlist/wishlist-featur.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+        - title: Product Management
+          nested:
+            - title: Product Attributes
+              url: /docs/scos/dev/features/product-management/product-attribu.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+                - '201907.0'
+            - title: Product
+              url: /docs/scos/dev/features/product-management/product.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+                - '201907.0'
+            - title: Discontinued Products
+              nested:
+                - title: Discontinued Products Feature Overview
+                  url: /docs/scos/dev/features/product-management/discontinued-products/discontinued-pr.html
+                  include_versions:
+                    - '201811.0'
+                    - '201903.0'
+                    - '201907.0'
+            - title: Product Bundles
+              url: /docs/scos/dev/features/product-management/product-bundle.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+                - '201907.0'
+            - title: Product Abstraction
+              url: /docs/scos/dev/features/product-management/product-abstrac.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+                - '201907.0'
+            - title: Alternative Products
+              nested:
+                - title: Alternative Products Feature Overview
+                  url: /docs/scos/dev/features/product-management/alternative-products/alternative-pro.html
+                  include_versions:
+                    - '201811.0'
+                    - '201903.0'
+                    - '201907.0'
+            - title: Timed Product Availability Feature Overview
+              nested:
+                - title: Timed Product Availability Feature Overview
+                  url: /docs/scos/dev/features/product-management/timed-product-availability-feature-overview/product-ttl-fea.html
+                  include_versions:
+                    - '201811.0'
+                    - '201903.0'
+                    - '201907.0'
+                - title: Timed Product Availability
+                  url: /docs/scos/dev/features/product-management/timed-product-availability-feature-overview/product-ttl.html
+                  include_versions:
+                    - '201811.0'
+                    - '201903.0'
+                    - '201907.0'
+            - title: Product Label
+              url: /docs/scos/dev/features/product-management/product-label.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+                - '201907.0'
+            - title: Super Attributes
+              url: /docs/scos/dev/features/product-management/super-attribute.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+                - '201907.0'
+            - title: Product Group
+              url: /docs/scos/dev/features/product-management/product-group.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+                - '201907.0'
+            - title: Product Management
+              url: /docs/scos/dev/features/product-management/product-managem.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+                - '201907.0'
+            - title: Product Reviews
+              url: /docs/scos/dev/features/product-management/product-reviews.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+                - '201907.0'
+            - title: Dynamic Product Labels
+              url: /docs/scos/dev/features/product-management/dynamic-product.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+                - '201907.0'
+            - title: New Products
+              url: /docs/scos/dev/features/product-management/new-products.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+                - '201907.0'
+            - title: Barcode Generator
+              nested:
+                - title: Barcode Generator Feature Overview
+                  url: /docs/scos/dev/features/product-management/barcode-generator/barcode-generat.html
+                  include_versions:
+                    - '201811.0'
+                    - '201903.0'
+                    - '201907.0'
+            - title: Product Quantity Restrictions
+              nested:
+                - title: Product Quantity Restrictions
+                  url: /docs/scos/dev/features/product-management/product-quantity-restrictions/product-quantit.html
+                  include_versions:
+                    - '201811.0'
+                    - '201903.0'
+                    - '201907.0'
+            - title: Product relations
+              nested:
+                - title: Product Relations Feature Overview
+                  url: /docs/scos/dev/features/product-management/product-relations/product-relatio.html
+                  include_versions:
+                    - '201811.0'
+                    - '201903.0'
+                    - '201907.0'
+            - title: Product Set
+              url: /docs/scos/dev/features/product-management/product-set.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+                - '201907.0'
+            - title: Filter &amp; Sort by Average Rating - Product Reviews
+              url: /docs/scos/dev/features/product-management/product-review-.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+                - '201907.0'
+            - title: Product options
+              nested:
+                - title: Product Options
+                  url: /docs/scos/dev/features/product-management/product-options/product-options.html
+                  include_versions:
+                    - '201811.0'
+                    - '201903.0'
+                    - '201907.0'
+        - title: Features
+          url: /docs/scos/dev/features/about-features.html
+          include_versions:
+            - '201811.0'
+            - '201903.0'
+            - '201907.0'
+        - title: About Features
+          url: /docs/scos/dev/features/about-features.html
+          include_versions:
+            - '202005.0'
+        - title: Approval process
+          nested:
+            - title: Approval Process- module relations
+              url: /docs/scos/dev/features/approval-process/approval-proces.html
+              include_versions:
+                - '202108.0'
+            - title: Approval Process feature overview
+              url: /docs/scos/dev/features/approval-process/approval-proces.html
+              include_versions:
+                - '202009.0'
+        - title: Multiple Carts feature overview
+          url: /docs/scos/dev/features/multiple-carts-.html
+          include_versions:
+            - '202108.0'
+        - title: Comments
+          nested:
+            - title: Comments- module relations
+              url: /docs/scos/dev/features/comments/comments-module.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+            - title: Comments feature overview
+              url: /docs/scos/dev/features/comments/comments-featur.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+            - title: Comments
+              url: /docs/scos/dev/features/comments/comments.html
+              include_versions:
+                - '202009.0'
+        - title: Reorder
+          nested:
+            - title: Reorder
+              url: /docs/scos/dev/features/reorder/reorder.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+        - title: Payments
+          nested:
+            - title: Payments- module relations
+              url: /docs/scos/dev/features/payments/payments-module.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+            - title: Payments feature overview
+              url: /docs/scos/dev/features/payments/payments-featur.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+            - title: Payments
+              url: /docs/scos/dev/features/payments/payments.html
+              include_versions:
+                - '202009.0'
+        - title: Prices
+          nested:
+            - title: Prices feature overview
+              nested:
+                - title: PriceProduct module details- reference information
+                  url: /docs/scos/dev/features/prices/prices-feature-overview/priceproduct-mo.html
+                  include_versions:
+                    - '202009.0'
+                    - '202108.0'
+                - title: Prices overview
+                  url: /docs/scos/dev/features/prices/prices-feature-overview/prices-overview.html
+                  include_versions:
+                    - '202108.0'
+                - title: Volume Prices overview
+                  url: /docs/scos/dev/features/prices/prices-feature-overview/volume-prices-o.html
+                  include_versions:
+                    - '202108.0'
+                - title: Money module- reference information
+                  url: /docs/scos/dev/features/prices/prices-feature-overview/money-module-re.html
+                  include_versions:
+                    - '202009.0'
+                    - '202108.0'
+                - title: Price
+                  url: /docs/scos/dev/features/prices/prices-feature-overview/price.html
+                  include_versions:
+                    - '202009.0'
+                - title: Volume prices
+                  url: /docs/scos/dev/features/prices/prices-feature-overview/volume-prices.html
+                  include_versions:
+                    - '202009.0'
+            - title: Prices
+              url: /docs/scos/dev/features/prices/prices.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+        - title: Mailing & Notifications feature overview
+          url: /docs/scos/dev/features/mailing-notific.html
+          include_versions:
+            - '202108.0'
+        - title: Content items
+          nested:
+            - title: Content Items feature overview
+              url: /docs/scos/dev/features/content-items/content-items-f.html
+              include_versions:
+                - '202108.0'
+            - title: Content item types- module relations
+              url: /docs/scos/dev/features/content-items/content-item-ty.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+            - title: Content items feature overview
+              url: /docs/scos/dev/features/content-items/content-items-f.html
+              include_versions:
+                - '202009.0'
+            - title: Content items
+              url: /docs/scos/dev/features/content-items/content-items.html
+              include_versions:
+                - '202009.0'
+        - title: Configurable Product
+          nested:
+            - title: Configurable Product feature overview
+              url: /docs/scos/dev/features/configurable-product/configurable-pr.html
+              include_versions:
+                - '202108.0'
+        - title: Spryker Core Back Office
+          nested:
+            - title: Spryker Core Back Office feature overview
+              nested:
+                - title: The Back Office overview
+                  url: /docs/scos/dev/features/spryker-core-back-office/spryker-core-back-office-feature-overview/the-back-office.html
+                  include_versions:
+                    - '202009.0'
+                    - '202108.0'
+                - title: Back Office Translations overview
+                  url: /docs/scos/dev/features/spryker-core-back-office/spryker-core-back-office-feature-overview/back-office-tra.html
+                  include_versions:
+                    - '202108.0'
+                - title: Back Office Login overview
+                  url: /docs/scos/dev/features/spryker-core-back-office/spryker-core-back-office-feature-overview/back-office-log.html
+                  include_versions:
+                    - '202108.0'
+                - title: Users and Rights overview
+                  url: /docs/scos/dev/features/spryker-core-back-office/spryker-core-back-office-feature-overview/user-and-rights.html
+                  include_versions:
+                    - '202009.0'
+                    - '202108.0'
+                - title: Back Office translations overview
+                  url: /docs/scos/dev/features/spryker-core-back-office/spryker-core-back-office-feature-overview/back-office-tra.html
+                  include_versions:
+                    - '202009.0'
+            - title: Spryker Core Back Office
+              url: /docs/scos/dev/features/spryker-core-back-office/spryker-core-ba.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+            - title: Back Office
+              url: /docs/scos/dev/features/spryker-core-back-office/back-office.html
+              include_versions:
+                - '202009.0'
+        - title: Non-splittable Products feature overview
+          url: /docs/scos/dev/features/product-quantit.html
+          include_versions:
+            - '202108.0'
+        - title: Product Groups feature overview
+          url: /docs/scos/dev/features/product-groups-.html
+          include_versions:
+            - '202108.0'
+        - title: Shopping Lists
+          nested:
+            - title: Printing a shopping list
+              nested:
+                - title: Printing a shopping list feature overview
+                  url: /docs/scos/dev/features/shopping-lists/printing-a-shopping-list/printing-shoppi.html
+                  include_versions:
+                    - '202108.0'
+            - title: Shopping Lists
+              url: /docs/scos/dev/features/shopping-lists/shopping-lists.html
+              include_versions:
+                - '202108.0'
+            - title: Shopping Lists feature overview
+              nested:
+                - title: Shopping List Notes overview
+                  url: /docs/scos/dev/features/shopping-lists/shopping-lists-feature-overview/shopping-list-n.html
+                  include_versions:
+                    - '202108.0'
+                - title: Shopping list widget overview
+                  url: /docs/scos/dev/features/shopping-lists/shopping-lists-feature-overview/shopping-list-w.html
+                  include_versions:
+                    - '202108.0'
+                - title: Multiple and Shared Shopping Lists overview
+                  url: /docs/scos/dev/features/shopping-lists/shopping-lists-feature-overview/multiple-and-sh.html
+                  include_versions:
+                    - '202108.0'
+        - title: Product Labels feature overview
+          url: /docs/scos/dev/features/product-labels-.html
+          include_versions:
+            - '202108.0'
+        - title: Product Bundles feature overview
+          url: /docs/scos/dev/features/product-bundles.html
+          include_versions:
+            - '202108.0'
+        - title: Merchant Product Restrictions
+          nested:
+            - title: Restricted products behavior
+              url: /docs/scos/dev/features/merchant-product-restrictions/restricted-prod.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+            - title: Merchant Product Restrictions feature overview
+              url: /docs/scos/dev/features/merchant-product-restrictions/merchant-produc.html
+              include_versions:
+                - '202108.0'
+            - title: Merchant Product Restrictions
+              url: /docs/scos/dev/features/merchant-product-restrictions/merchant-produc.html
+              include_versions:
+                - '202009.0'
+        - title: Reclamations
+          nested:
+            - title: Reclamations
+              url: /docs/scos/dev/features/reclamations/reclamations.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+            - title: Reclamations feature overview
+              url: /docs/scos/dev/features/reclamations/reclamations-fe.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+        - title: Quotation Process
+          nested:
+            - title: Quotation Process feature overview
+              url: /docs/scos/dev/features/quotation-process/quotation-proce.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+        - title: Company account
+          nested:
+            - title: Company Account
+              url: /docs/scos/dev/features/company-account/company-account.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+            - title: Company Account feature overview
+              nested:
+                - title: Customer Login by Token overview
+                  url: /docs/scos/dev/features/company-account/company-account-feature-overview/customer-login-.html
+                  include_versions:
+                    - '202108.0'
+                - title: Company Accounts overview
+                  url: /docs/scos/dev/features/company-account/company-account-feature-overview/company-account.html
+                  include_versions:
+                    - '202108.0'
+                - title: Company user roles and permissions overview
+                  url: /docs/scos/dev/features/company-account/company-account-feature-overview/company-user-ro.html
+                  include_versions:
+                    - '202108.0'
+                - title: Business on Behalf overview
+                  url: /docs/scos/dev/features/company-account/company-account-feature-overview/business-on-beh.html
+                  include_versions:
+                    - '202108.0'
+                - title: Business Units overview
+                  url: /docs/scos/dev/features/company-account/company-account-feature-overview/business-units-.html
+                  include_versions:
+                    - '202108.0'
+                - title: Customer Login by Token
+                  url: /docs/scos/dev/features/company-account/company-account-feature-overview/customer-login-.html
+                  include_versions:
+                    - '202009.0'
+                - title: Company accounts
+                  url: /docs/scos/dev/features/company-account/company-account-feature-overview/company-account.html
+                  include_versions:
+                    - '202009.0'
+                - title: Company user roles and permissions
+                  url: /docs/scos/dev/features/company-account/company-account-feature-overview/company-user-ro.html
+                  include_versions:
+                    - '202009.0'
+                - title: Business on behalf
+                  url: /docs/scos/dev/features/company-account/company-account-feature-overview/business-on-beh.html
+                  include_versions:
+                    - '202009.0'
+                - title: Business units
+                  url: /docs/scos/dev/features/company-account/company-account-feature-overview/business-units.html
+                  include_versions:
+                    - '202009.0'
+        - title: Product
+          nested:
+            - title: Product
+              url: /docs/scos/dev/features/product/product.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+            - title: Product feature overview
+              nested:
+                - title: Product Attributes overview
+                  url: /docs/scos/dev/features/product/product-feature-overview/product-attribu.html
+                  include_versions:
+                    - '202108.0'
+                - title: Products overview
+                  url: /docs/scos/dev/features/product/product-feature-overview/products-overvi.html
+                  include_versions:
+                    - '202108.0'
+                - title: Search widget for concrete products overview
+                  url: /docs/scos/dev/features/product/product-feature-overview/search-widget-f.html
+                  include_versions:
+                    - '202108.0'
+                - title: Product Images overview
+                  url: /docs/scos/dev/features/product/product-feature-overview/product-images-.html
+                  include_versions:
+                    - '202108.0'
+                - title: Timed Product Availability overview
+                  url: /docs/scos/dev/features/product/product-feature-overview/timed-product-a.html
+                  include_versions:
+                    - '202108.0'
+                - title: Discontinued Products overview
+                  url: /docs/scos/dev/features/product/product-feature-overview/discontinued-pr.html
+                  include_versions:
+                    - '202108.0'
+                - title: Product attribute overview
+                  url: /docs/scos/dev/features/product/product-feature-overview/product-attribu.html
+                  include_versions:
+                    - '202009.0'
+                - title: Product overview
+                  url: /docs/scos/dev/features/product/product-feature-overview/product-overvie.html
+                  include_versions:
+                    - '202009.0'
+                - title: Timed product availability overview
+                  url: /docs/scos/dev/features/product/product-feature-overview/timed-product-a.html
+                  include_versions:
+                    - '202009.0'
+                - title: Product image management
+                  url: /docs/scos/dev/features/product/product-feature-overview/product-image-m.html
+                  include_versions:
+                    - '202009.0'
+                - title: Discontinued product overview
+                  url: /docs/scos/dev/features/product/product-feature-overview/discontinued-pr.html
+                  include_versions:
+                    - '202009.0'
+        - title: Merchant Custom Prices feature overview
+          url: /docs/scos/dev/features/merchant-custom.html
+          include_versions:
+            - '202108.0'
+        - title: Search
+          nested:
+            - title: Search
+              url: /docs/scos/dev/features/search/search.html
+              include_versions:
+                - '202108.0'
+            - title: Search feature overview
+              nested:
+                - title: Standard filters overview
+                  url: /docs/scos/dev/features/search/search-feature-overview/standard-filter.html
+                  include_versions:
+                    - '202108.0'
+                - title: Search types overview
+                  url: /docs/scos/dev/features/search/search-feature-overview/search-types-ov.html
+                  include_versions:
+                    - '202108.0'
+                - title: Category filters overview
+                  url: /docs/scos/dev/features/search/search-feature-overview/category-filter.html
+                  include_versions:
+                    - '202108.0'
+        - title: Customer Access feature overview
+          url: /docs/scos/dev/features/customer-access.html
+          include_versions:
+            - '202108.0'
+        - title: Return management
+          nested:
+            - title: Building a return management process- Best practices
+              url: /docs/scos/dev/features/return-management/building-a-retu.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+            - title: Return management
+              url: /docs/scos/dev/features/return-management/return-manageme.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+        - title: Packaging Units feature overview
+          url: /docs/scos/dev/features/packaging-units.html
+          include_versions:
+            - '202108.0'
+        - title: Spryker Core
+          nested:
+            - title: Spryker Core
+              url: /docs/scos/dev/features/spryker-core/spryker-core.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+            - title: Spryker Core feature overview
+              nested:
+                - title: URL Redirects overview
+                  url: /docs/scos/dev/features/spryker-core/spryker-core-feature-overview/url-redirects-o.html
+                  include_versions:
+                    - '202108.0'
+                - title: Vault for Tokens overview
+                  url: /docs/scos/dev/features/spryker-core/spryker-core-feature-overview/vault-for-token.html
+                  include_versions:
+                    - '202108.0'
+                - title: How translations are managed
+                  url: /docs/scos/dev/features/spryker-core/spryker-core-feature-overview/glossary-how-tr.html
+                  include_versions:
+                    - '202009.0'
+                    - '202108.0'
+                - title: URL redirects
+                  url: /docs/scos/dev/features/spryker-core/spryker-core-feature-overview/url-redirects.html
+                  include_versions:
+                    - '202009.0'
+                - title: Vault for tokens
+                  url: /docs/scos/dev/features/spryker-core/spryker-core-feature-overview/vault-for-token.html
+                  include_versions:
+                    - '202009.0'
+                - title: Managing glossary keys
+                  url: /docs/scos/dev/features/spryker-core/spryker-core-feature-overview/glossary-keys.html
+                  include_versions:
+                    - '202009.0'
+            - title: Internationalization
+              url: /docs/scos/dev/features/spryker-core/internationaliz.html
+              include_versions:
+                - '202009.0'
+        - title: Alternative Products feature overview
+          url: /docs/scos/dev/features/alternative-pro.html
+          include_versions:
+            - '202108.0'
+        - title: Gift Cards feature overview
+          url: /docs/scos/dev/features/gift-cards-feat.html
+          include_versions:
+            - '202108.0'
+        - title: Shared Carts
+          nested:
+            - title: Shared Carts
+              url: /docs/scos/dev/features/shared-carts/shared-carts.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+            - title: Shared Carts feature overview
+              url: /docs/scos/dev/features/shared-carts/shared-carts-fe.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+        - title: Measurement Units feature overview
+          url: /docs/scos/dev/features/measurement-uni.html
+          include_versions:
+            - '202108.0'
+        - title: Category Management feature overview
+          url: /docs/scos/dev/features/category-manage.html
+          include_versions:
+            - '202108.0'
+        - title: Catalog
+          url: /docs/scos/dev/features/catalog.html
+          include_versions:
+            - '202108.0'
+        - title: Availability Notification
+          nested:
+            - title: Availability Notification- module relations
+              url: /docs/scos/dev/features/availability-notification/availability-no.html
+              include_versions:
+                - '202108.0'
+            - title: Availability  Notification feature overview
+              url: /docs/scos/dev/features/availability-notification/availability-no.html
+              include_versions:
+                - '202009.0'
+        - title: Cart
+          nested:
+            - title: Cart feature overview
+              nested:
+                - title: Cart Notes overview
+                  url: /docs/scos/dev/features/cart/cart-feature-overview/cart-notes-over.html
+                  include_versions:
+                    - '202108.0'
+                - title: Cart Widget overview
+                  url: /docs/scos/dev/features/cart/cart-feature-overview/cart-widget-ove.html
+                  include_versions:
+                    - '202108.0'
+                - title: Cart module- Reference information
+                  url: /docs/scos/dev/features/cart/cart-feature-overview/cart-module-ref.html
+                  include_versions:
+                    - '202009.0'
+                    - '202108.0'
+                - title: Calculation 3.0
+                  url: /docs/scos/dev/features/cart/cart-feature-overview/calculation-3-0.html
+                  include_versions:
+                    - '202009.0'
+                    - '202108.0'
+                - title: Calculation data structure
+                  url: /docs/scos/dev/features/cart/cart-feature-overview/calculation-dat.html
+                  include_versions:
+                    - '202009.0'
+                    - '202108.0'
+                - title: Quick Order from the Catalog Page overview
+                  url: /docs/scos/dev/features/cart/cart-feature-overview/quick-order-fro.html
+                  include_versions:
+                    - '202108.0'
+                - title: Calculator plugins
+                  url: /docs/scos/dev/features/cart/cart-feature-overview/calculator-plug.html
+                  include_versions:
+                    - '202009.0'
+                    - '202108.0'
+                - title: Cart notes overview
+                  url: /docs/scos/dev/features/cart/cart-feature-overview/cart-notes-over.html
+                  include_versions:
+                    - '202009.0'
+                - title: Cart widget overview
+                  url: /docs/scos/dev/features/cart/cart-feature-overview/cart-widget-ove.html
+                  include_versions:
+                    - '202009.0'
+                - title: Quick order from the catalog page overview
+                  url: /docs/scos/dev/features/cart/cart-feature-overview/quick-order-fro.html
+                  include_versions:
+                    - '202009.0'
+            - title: Cart
+              url: /docs/scos/dev/features/cart/cart.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+        - title: Configurable Bundle
+          nested:
+            - title: Configurable bundle- module relations
+              url: /docs/scos/dev/features/configurable-bundle/configurable-bu.html
+              include_versions:
+                - '202108.0'
+            - title: Configurable Bundle feature overview
+              url: /docs/scos/dev/features/configurable-bundle/configurable-bu.html
+              include_versions:
+                - '202009.0'
+        - title: Product relations
+          nested:
+            - title: Product Relations feature overview
+              url: /docs/scos/dev/features/product-relations/product-relatio.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+        - title: Resource Sharing
+          nested:
+            - title: Resource Sharing feature overview
+              url: /docs/scos/dev/features/resource-sharing/resource-sharin.html
+              include_versions:
+                - '202108.0'
+            - title: Unique URL per cart for easy sharing
+              nested:
+                - title: Unique URL per Cart for Easy Sharing- module relations
+                  url: /docs/scos/dev/features/resource-sharing/unique-url-per-cart-for-easy-sharing/unique-url-per-.html
+                  include_versions:
+                    - '202009.0'
+        - title: Refunds
+          nested:
+            - title: Refunds
+              url: /docs/scos/dev/features/refunds/refunds.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+        - title: File Manager
+          nested:
+            - title: File Manager
+              url: /docs/scos/dev/features/file-manager/media-managemen.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+            - title: File Manager feature overview
+              nested:
+                - title: Asset management
+                  url: /docs/scos/dev/features/file-manager/file-manager-feature-overview/asset-managemen.html
+                  include_versions:
+                    - '202009.0'
+                    - '202108.0'
+                - title: File uploader
+                  url: /docs/scos/dev/features/file-manager/file-manager-feature-overview/file-uploader.html
+                  include_versions:
+                    - '202009.0'
+                    - '202108.0'
+        - title: Persistent Cart Sharing
+          nested:
+            - title: Persistent Cart Sharing feature overview
+              url: /docs/scos/dev/features/persistent-cart-sharing/persistent-cart.html
+              include_versions:
+                - '202108.0'
+            - title: Persistent Cart Sharing- module relations
+              url: /docs/scos/dev/features/persistent-cart-sharing/unique-url-per-.html
+              include_versions:
+                - '202108.0'
+        - title: Quick Add to Cart
+          nested:
+            - title: Quick Add to Cart- module relations
+              url: /docs/scos/dev/features/quick-add-to-cart/quick-add-to-ca.html
+              include_versions:
+                - '202108.0'
+        - title: Product lists
+          nested:
+            - title: Product Lists
+              url: /docs/scos/dev/features/product-lists/product-lists.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+        - title: Product options
+          nested:
+            - title: Product Options
+              url: /docs/scos/dev/features/product-options/product-options.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+        - title: Product Barcode feature overview
+          url: /docs/scos/dev/features/product-barcode.html
+          include_versions:
+            - '202108.0'
+        - title: Product Rating & Reviews
+          nested:
+            - title: Product Rating & Reviews
+              url: /docs/scos/dev/features/product-rating-and-reviews/product-rating-.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+        - title: Agent Assist feature overview
+          url: /docs/scos/dev/features/agent-assist-ov.html
+          include_versions:
+            - '202108.0'
+        - title: Product labels
+          nested:
+            - title: Product Labels
+              url: /docs/scos/dev/features/product-labels/product-labels.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+            - title: Product Labels feature overview
+              url: /docs/scos/dev/features/product-labels/product-labels-.html
+              include_versions:
+                - '202009.0'
+        - title: Scheduled prices
+          nested:
+            - title: Scheduled prices feature overview
+              url: /docs/scos/dev/features/scheduled-prices/scheduled-price.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+        - title: Customer Account Management
+          nested:
+            - title: Customer Account Management feature overview
+              nested:
+                - title: Customer Login overview
+                  url: /docs/scos/dev/features/customer-account-management/customer-account-management-feature-overview/customer-login-.html
+                  include_versions:
+                    - '202108.0'
+                - title: Password Management overview
+                  url: /docs/scos/dev/features/customer-account-management/customer-account-management-feature-overview/password-manage.html
+                  include_versions:
+                    - '202009.0'
+                    - '202108.0'
+                - title: Reference information- Customer module overview
+                  url: /docs/scos/dev/features/customer-account-management/customer-account-management-feature-overview/reference-infor.html
+                  include_versions:
+                    - '202009.0'
+                    - '202108.0'
+                - title: Customer Groups overview
+                  url: /docs/scos/dev/features/customer-account-management/customer-account-management-feature-overview/customer-groups.html
+                  include_versions:
+                    - '202009.0'
+                    - '202108.0'
+                - title: Customer Registration overview
+                  url: /docs/scos/dev/features/customer-account-management/customer-account-management-feature-overview/customer-regist.html
+                  include_versions:
+                    - '202009.0'
+                    - '202108.0'
+                - title: Customer Accounts overview
+                  url: /docs/scos/dev/features/customer-account-management/customer-account-management-feature-overview/customer-accoun.html
+                  include_versions:
+                    - '202108.0'
+                - title: Customer Account overview
+                  url: /docs/scos/dev/features/customer-account-management/customer-account-management-feature-overview/customer-accoun.html
+                  include_versions:
+                    - '202009.0'
+            - title: Customer Account Management
+              url: /docs/scos/dev/features/customer-account-management/customer-accoun.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+        - title: Merchant B2B Contracts feature overview
+          url: /docs/scos/dev/features/merchant-b2b-co.html
+          include_versions:
+            - '202108.0'
+        - title: Product sets
+          nested:
+            - title: Product Sets feature overview
+              url: /docs/scos/dev/features/product-sets/product-sets-fe.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+            - title: Product Sets- module relations
+              url: /docs/scos/dev/features/product-sets/product-sets-mo.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+            - title: Product Sets
+              url: /docs/scos/dev/features/product-sets/product-set.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+        - title: Product Barcode
+          nested:
+            - title: Product Barcode feature overview
+              url: /docs/scos/dev/features/product-barcode/product-barcode.html
+              include_versions:
+                - '202009.0'
+        - title: Product Bundles
+          nested:
+            - title: Product Bundles
+              url: /docs/scos/dev/features/product-bundles/product-bundles.html
+              include_versions:
+                - '202009.0'
+        - title: Alternative Products
+          nested:
+            - title: Alternative Products feature overview
+              url: /docs/scos/dev/features/alternative-products/alternative-pro.html
+              include_versions:
+                - '202009.0'
+        - title: Merchant Custom Prices
+          nested:
+            - title: Merchant Custom Prices
+              url: /docs/scos/dev/features/merchant-custom-prices/merchant-custom.html
+              include_versions:
+                - '202009.0'
+        - title: Category Management
+          nested:
+            - title: Category Management feature overview
+              url: /docs/scos/dev/features/category-management/category-manage.html
+              include_versions:
+                - '202009.0'
+        - title: Non-splittable Products
+          nested:
+            - title: Non-splittable Products feature overview
+              url: /docs/scos/dev/features/non-splittable-products/product-quantit.html
+              include_versions:
+                - '202009.0'
+            - title: Non-splittable Products
+              url: /docs/scos/dev/features/non-splittable-products/non-splittable-.html
+              include_versions:
+                - '202009.0'
+        - title: Agent Assist
+          nested:
+            - title: Agent Assist
+              url: /docs/scos/dev/features/agent-assist/agent-assist.html
+              include_versions:
+                - '202009.0'
+            - title: Agent Assist feature overview
+              url: /docs/scos/dev/features/agent-assist/agent-assist-ov.html
+              include_versions:
+                - '202009.0'
+        - title: Packaging units
+          nested:
+            - title: Packaging units feature overview
+              url: /docs/scos/dev/features/packaging-units/packaging-units.html
+              include_versions:
+                - '202009.0'
+        - title: Measurement units
+          nested:
+            - title: Measurement units feature overview
+              url: /docs/scos/dev/features/measurement-units/measurement-uni.html
+              include_versions:
+                - '202009.0'
+        - title: Mailing & Notifications
+          nested:
+            - title: Mailing & Notifications
+              url: /docs/scos/dev/features/mailing-and-notifications/mailing-notific.html
+              include_versions:
+                - '202009.0'
+            - title: Mailing & Notifications feature overview
+              nested:
+                - title: Transactional email management
+                  url: /docs/scos/dev/features/mailing-and-notifications/mailing-and-notifications-feature-overview/transactional-e.html
+                  include_versions:
+                    - '202009.0'
+                - title: Newsletter subscription
+                  url: /docs/scos/dev/features/mailing-and-notifications/mailing-and-notifications-feature-overview/newsletter-subs.html
+                  include_versions:
+                    - '202009.0'
+        - title: Customer Access
+          nested:
+            - title: Customer Access feature overview
+              url: /docs/scos/dev/features/customer-access/customer-access.html
+              include_versions:
+                - '202009.0'
+        - title: Product Groups
+          nested:
+            - title: Product Groups
+              url: /docs/scos/dev/features/product-groups/product-groups.html
+              include_versions:
+                - '202009.0'
+            - title: Product Groups feature overview
+              url: /docs/scos/dev/features/product-groups/product-group-f.html
+              include_versions:
+                - '202009.0'
+        - title: Multiple Carts
+          nested:
+            - title: Multiple Carts feature overview
+              url: /docs/scos/dev/features/multiple-carts/multiple-carts-.html
+              include_versions:
+                - '202009.0'
+            - title: Multiple Carts
+              url: /docs/scos/dev/features/multiple-carts/multiple-carts.html
+              include_versions:
+                - '202009.0'
+        - title: Merchant B2B Contracts
+          nested:
+            - title: Merchant B2B Contracts
+              url: /docs/scos/dev/features/merchant-b2b-contracts/merchants-b2b-c.html
+              include_versions:
+                - '202009.0'
+            - title: Merchant B2B Contracts feature overview
+              url: /docs/scos/dev/features/merchant-b2b-contracts/merchant-b2b-co.html
+              include_versions:
+                - '202009.0'
+    - title: Glue API
+      nested:
+        - title: Glue API Storefront Guides
+          nested:
+            - title: Retrieving Navigation Trees
+              url: /docs/scos/dev/glue-api/glue-api-storefront-guides/retrieving-navi.html
+              include_versions:
+                - '201903.0'
+                - '201907.0'
+                - '202001.0'
+            - title: Getting the List of Protected Resources
+              url: /docs/scos/dev/glue-api/glue-api-storefront-guides/getting-the-lis.html
+              include_versions:
+                - '202001.0'
+            - title: Browsing a Category Tree
+              url: /docs/scos/dev/glue-api/glue-api-storefront-guides/retrieving-cate.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+                - '201907.0'
+                - '202001.0'
+            - title: Managing Wishlists
+              url: /docs/scos/dev/glue-api/glue-api-storefront-guides/managing-wishli.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+                - '201907.0'
+                - '202001.0'
+            - title: Discounts and Promotions
+              url: /docs/scos/dev/glue-api/glue-api-storefront-guides/retrieving-disc.html
+              include_versions:
+                - '202001.0'
+            - title: Retrieving Store Configuration
+              url: /docs/scos/dev/glue-api/glue-api-storefront-guides/retrieving-stor.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+                - '201907.0'
+                - '202001.0'
+            - title: Retrieving Content Item Data
+              nested:
+                - title: Getting Abstract Product List Content Item Data
+                  url: /docs/scos/dev/glue-api/glue-api-storefront-guides/retrieving-content-item-data/getting-abstrac.html
+                  include_versions:
+                    - '201907.0'
+                    - '202001.0'
+                - title: Retrieving Content Item Data
+                  url: /docs/scos/dev/glue-api/glue-api-storefront-guides/retrieving-content-item-data/retrieving-cont.html
+                  include_versions:
+                    - '201907.0'
+                    - '202001.0'
+                - title: Retrieving Banner Content Item Data
+                  url: /docs/scos/dev/glue-api/glue-api-storefront-guides/retrieving-content-item-data/retrieving-bann.html
+                  include_versions:
+                    - '201907.0'
+                    - '202001.0'
+            - title: Managing carts
+              nested:
+                - title: Managing Carts of Registered Users
+                  url: /docs/scos/dev/glue-api/glue-api-storefront-guides/managing-carts/managing-carts-.html
+                  include_versions:
+                    - '201811.0'
+                    - '201903.0'
+                    - '201907.0'
+                    - '202001.0'
+                - title: Managing Carts
+                  url: /docs/scos/dev/glue-api/glue-api-storefront-guides/managing-carts/managing-carts.html
+                  include_versions:
+                    - '201811.0'
+                    - '201903.0'
+                    - '201907.0'
+                    - '202001.0'
+                - title: Managing Guest Carts
+                  url: /docs/scos/dev/glue-api/glue-api-storefront-guides/managing-carts/managing-guest-.html
+                  include_versions:
+                    - '201811.0'
+                    - '201903.0'
+                    - '201907.0'
+                    - '202001.0'
+                - title: Sharing Company User Carts
+                  url: /docs/scos/dev/glue-api/glue-api-storefront-guides/managing-carts/sharing-company.html
+                  include_versions:
+                    - '201907.0'
+                    - '202001.0'
+            - title: Authentication and Authorization
+              url: /docs/scos/dev/glue-api/glue-api-storefront-guides/authentication-.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+                - '201907.0'
+                - '202001.0'
+            - title: Getting Suggestions for Auto-Completion and Search
+              url: /docs/scos/dev/glue-api/glue-api-storefront-guides/retrieving-sugg.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+                - '201907.0'
+                - '202001.0'
+            - title: Retrieving Ratings and Reviews
+              url: /docs/scos/dev/glue-api/glue-api-storefront-guides/retrieving-rati.html
+              include_versions:
+                - '202001.0'
+            - title: Catalog Search
+              url: /docs/scos/dev/glue-api/glue-api-storefront-guides/catalog-search.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+                - '201907.0'
+                - '202001.0'
+            - title: Checking Out Purchases and Getting Checkout Data
+              url: /docs/scos/dev/glue-api/glue-api-storefront-guides/checking-out-pu.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+                - '201907.0'
+                - '202001.0'
+            - title: Retrieving Customer's Order History
+              url: /docs/scos/dev/glue-api/glue-api-storefront-guides/retrieving-orde.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+                - '201907.0'
+                - '202001.0'
+            - title: Managing products
+              nested:
+                - title: Retrieving Alternative Products
+                  url: /docs/scos/dev/glue-api/glue-api-storefront-guides/managing-products/retrieving-alte.html
+                  include_versions:
+                    - '201903.0'
+                    - '201907.0'
+                    - '202001.0'
+                - title: Retrieving Product Information
+                  url: /docs/scos/dev/glue-api/glue-api-storefront-guides/managing-products/retrieving-prod.html
+                  include_versions:
+                    - '201811.0'
+                    - '201903.0'
+                    - '201907.0'
+                    - '202001.0'
+                - title: Retrieving Related Products
+                  url: /docs/scos/dev/glue-api/glue-api-storefront-guides/managing-products/retrieving-rela.html
+                  include_versions:
+                    - '201903.0'
+                    - '201907.0'
+                    - '202001.0'
+            - title: Handling Concurrent REST Requests and Caching with Etags
+              url: /docs/scos/dev/glue-api/glue-api-storefront-guides/handling-concur.html
+              include_versions:
+                - '201907.0'
+                - '202001.0'
+            - title: B2B Account Management
+              nested:
+                - title: Retrieving Company Role Information
+                  url: /docs/scos/dev/glue-api/glue-api-storefront-guides/b2b-account-management/retrieving-comp.html
+                  include_versions:
+                    - '201907.0'
+                    - '202001.0'
+                - title: Logging In as Company User
+                  url: /docs/scos/dev/glue-api/glue-api-storefront-guides/b2b-account-management/logging-in-as-c.html
+                  include_versions:
+                    - '201907.0'
+                    - '202001.0'
+                - title: Retrieving Business Unit Information
+                  url: /docs/scos/dev/glue-api/glue-api-storefront-guides/b2b-account-management/retrieving-busi.html
+                  include_versions:
+                    - '201907.0'
+                    - '202001.0'
+                - title: B2B Account Management
+                  url: /docs/scos/dev/glue-api/glue-api-storefront-guides/b2b-account-management/b2b-account-man.html
+                  include_versions:
+                    - '202001.0'
+            - title: Using Search Engine Friendly URLs
+              url: /docs/scos/dev/glue-api/glue-api-storefront-guides/using-search-en.html
+              include_versions:
+                - '202001.0'
+            - title: Managing Customers
+              url: /docs/scos/dev/glue-api/glue-api-storefront-guides/managing-custom.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+                - '201907.0'
+                - '202001.0'
+        - title: Glue REST API
+          url: /docs/scos/dev/glue-api/glue-rest-api.html
+          include_versions:
+            - '201811.0'
+            - '201903.0'
+            - '201907.0'
+            - '202001.0'
+        - title: B2C API React Example
+          nested:
+            - title: B2C API React Example
+              url: /docs/scos/dev/glue-api/b2c-api-react-example/b2c-api-react-e.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+                - '201907.0'
+                - '202001.0'
+        - title: Glue API Developer Guides
+          nested:
+            - title: Security and Authentication
+              url: /docs/scos/dev/glue-api/glue-api-developer-guides/security-and-au.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+                - '201907.0'
+                - '202001.0'
+            - title: Glue API Developer Guides
+              url: /docs/scos/dev/glue-api/glue-api-developer-guides/glue-api-develo.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+                - '201907.0'
+                - '202001.0'
+            - title: Glue Spryks
+              url: /docs/scos/dev/glue-api/glue-api-developer-guides/glue-spryks.html
+              include_versions:
+                - '202001.0'
+            - title: Glue Infrastructure
+              url: /docs/scos/dev/glue-api/glue-api-developer-guides/glue-infrastruc.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+                - '201907.0'
+                - '202001.0'
+        - title: REST API Reference
+          url: /docs/scos/dev/glue-api/rest-api-refere.html
+          include_versions:
+            - '201811.0'
+            - '201903.0'
+            - '201907.0'
+            - '202001.0'
+    - title: Developer's Corner
+      nested:
+        - title: Developer's Corner
+          url: /docs/scos/dev/developers-corner/developers-corn.html
+          include_versions:
+            - '201903.0'
+    - title: Database Schema Guide
+      nested:
+        - title: Catalog Schema
+          url: /docs/scos/dev/database-schema-guide/db-schema-catal.html
+          include_versions:
+            - '201903.0'
+        - title: Marketplace Schema
+          url: /docs/scos/dev/database-schema-guide/db-schema-marke.html
+          include_versions:
+            - '201903.0'
+        - title: Customer Schema
+          url: /docs/scos/dev/database-schema-guide/db-schema-custo.html
+          include_versions:
+            - '201903.0'
+        - title: Zed Administration Schema
+          url: /docs/scos/dev/database-schema-guide/db-schema-zed-a.html
+          include_versions:
+            - '201903.0'
+        - title: Shipment Schema
+          url: /docs/scos/dev/database-schema-guide/db-schema-shipm.html
+          include_versions:
+            - '201903.0'
+        - title: Database Schema Guide
+          url: /docs/scos/dev/database-schema-guide/database-schema.html
+          include_versions:
+            - '201903.0'
+        - title: Company Account Schema
+          url: /docs/scos/dev/database-schema-guide/db-schema-compa.html
+          include_versions:
+            - '201903.0'
+        - title: URL Schema
+          url: /docs/scos/dev/database-schema-guide/db-schema-url.html
+          include_versions:
+            - '201903.0'
+        - title: Sales Schema
+          url: /docs/scos/dev/database-schema-guide/db-schema-sales.html
+          include_versions:
+            - '201903.0'
+        - title: Gift Cards Schema
+          url: /docs/scos/dev/database-schema-guide/db-schema-gift-.html
+          include_versions:
+            - '201903.0'
+        - title: Discounts Schema
+          url: /docs/scos/dev/database-schema-guide/db-schema-disco.html
+          include_versions:
+            - '201903.0'
+        - title: CMS Schema
+          url: /docs/scos/dev/database-schema-guide/db-schema-cms.html
+          include_versions:
+            - '201903.0'
+        - title: Navigation Schema
+          url: /docs/scos/dev/database-schema-guide/db-schema-navig.html
+          include_versions:
+            - '201903.0'
+        - title: Tax Schema
+          url: /docs/scos/dev/database-schema-guide/db-schema-tax.html
+          include_versions:
+            - '201903.0'
+    - title: Glue API guides
+      nested:
+        - title: Retrieving Navigation Trees
+          url: /docs/scos/dev/glue-api-guides/retrieving-navi.html
+          include_versions:
+            - '202005.0'
+        - title: Retrieving Measurement Units
+          url: /docs/scos/dev/glue-api-guides/retrieving-meas.html
+          include_versions:
+            - '202005.0'
+        - title: Getting the List of Protected Resources
+          url: /docs/scos/dev/glue-api-guides/getting-the-lis.html
+          include_versions:
+            - '202005.0'
+        - title: Browsing a Category Tree
+          url: /docs/scos/dev/glue-api-guides/retrieving-cate.html
+          include_versions:
+            - '202005.0'
+        - title: Managing Wishlists
+          url: /docs/scos/dev/glue-api-guides/managing-wishli.html
+          include_versions:
+            - '202005.0'
+        - title: Glue REST API
+          url: /docs/scos/dev/glue-api-guides/glue-rest-api.html
+          include_versions:
+            - '202005.0'
+            - '202009.0'
+            - '202108.0'
+        - title: Retrieving Store Configuration
+          url: /docs/scos/dev/glue-api-guides/retrieving-stor.html
+          include_versions:
+            - '202005.0'
+        - title: Retrieving Content Item Data
+          nested:
+            - title: Getting Abstract Product List Content Item Data
+              url: /docs/scos/dev/glue-api-guides/retrieving-content-item-data/getting-abstrac.html
+              include_versions:
+                - '202005.0'
+            - title: Retrieving Content Item Data
+              url: /docs/scos/dev/glue-api-guides/retrieving-content-item-data/retrieving-cont.html
+              include_versions:
+                - '202005.0'
+            - title: Retrieving Banner Content Item Data
+              url: /docs/scos/dev/glue-api-guides/retrieving-content-item-data/retrieving-bann.html
+              include_versions:
+                - '202005.0'
+        - title: Managing carts
+          nested:
+            - title: Managing Carts of Registered Users
+              url: /docs/scos/dev/glue-api-guides/managing-carts/managing-carts-.html
+              include_versions:
+                - '202005.0'
+            - title: Managing Carts
+              url: /docs/scos/dev/glue-api-guides/managing-carts/managing-carts.html
+              include_versions:
+                - '202005.0'
+            - title: Managing Guest Carts
+              url: /docs/scos/dev/glue-api-guides/managing-carts/managing-guest-.html
+              include_versions:
+                - '202005.0'
+            - title: Sharing Company User Carts
+              url: /docs/scos/dev/glue-api-guides/managing-carts/sharing-company.html
+              include_versions:
+                - '202005.0'
+            - title: Carts of registered users
+              nested:
+                - title: Managing items in carts of registered users
+                  url: /docs/scos/dev/glue-api-guides/managing-carts/carts-of-registered-users/managing-items-.html
+                  include_versions:
+                    - '202009.0'
+                    - '202108.0'
+                - title: Managing carts of registered users
+                  url: /docs/scos/dev/glue-api-guides/managing-carts/carts-of-registered-users/managing-carts-.html
+                  include_versions:
+                    - '202009.0'
+                    - '202108.0'
+                - title: Managing gift cards of registered users
+                  url: /docs/scos/dev/glue-api-guides/managing-carts/carts-of-registered-users/managing-gift-c.html
+                  include_versions:
+                    - '202009.0'
+                    - '202108.0'
+                - title: Managing discount vouchers in carts of registered users
+                  url: /docs/scos/dev/glue-api-guides/managing-carts/carts-of-registered-users/managing-discou.html
+                  include_versions:
+                    - '202009.0'
+                    - '202108.0'
+            - title: Guest carts
+              nested:
+                - title: Managing guest carts
+                  url: /docs/scos/dev/glue-api-guides/managing-carts/guest-carts/managing-guest-.html
+                  include_versions:
+                    - '202009.0'
+                    - '202108.0'
+                - title: Managing gift cards of guest users
+                  url: /docs/scos/dev/glue-api-guides/managing-carts/guest-carts/managing-gift-c.html
+                  include_versions:
+                    - '202009.0'
+                    - '202108.0'
+                - title: Managing discount vouchers in guest carts
+                  url: /docs/scos/dev/glue-api-guides/managing-carts/guest-carts/managing-discou.html
+                  include_versions:
+                    - '202009.0'
+                    - '202108.0'
+            - title: Sharing company user carts
+              nested:
+                - title: Managing shared company user carts
+                  url: /docs/scos/dev/glue-api-guides/managing-carts/sharing-company-user-carts/managing-shared.html
+                  include_versions:
+                    - '202009.0'
+                    - '202108.0'
+                - title: Retrieving cart permission groups
+                  url: /docs/scos/dev/glue-api-guides/managing-carts/sharing-company-user-carts/retrieving-cart.html
+                  include_versions:
+                    - '202009.0'
+                    - '202108.0'
+                - title: Sharing company user carts
+                  url: /docs/scos/dev/glue-api-guides/managing-carts/sharing-company-user-carts/sharing-company.html
+                  include_versions:
+                    - '202009.0'
+                    - '202108.0'
+        - title: Retrieving Return Management Information
+          nested:
+            - title: Retrieving the Returned Items
+              url: /docs/scos/dev/glue-api-guides/retrieving-return-management-information/retrieving-the-.html
+              include_versions:
+                - '202005.0'
+            - title: Creating a Return
+              url: /docs/scos/dev/glue-api-guides/retrieving-return-management-information/creating-a-retu.html
+              include_versions:
+                - '202005.0'
+            - title: Retrieving Returnable Items
+              url: /docs/scos/dev/glue-api-guides/retrieving-return-management-information/retrieving-retu.html
+              include_versions:
+                - '202005.0'
+        - title: Authentication and Authorization
+          url: /docs/scos/dev/glue-api-guides/authentication-.html
+          include_versions:
+            - '202005.0'
+        - title: Getting Suggestions for Auto-Completion and Search
+          url: /docs/scos/dev/glue-api-guides/retrieving-sugg.html
+          include_versions:
+            - '202005.0'
+        - title: Retrieving Ratings and Reviews
+          url: /docs/scos/dev/glue-api-guides/retrieving-rati.html
+          include_versions:
+            - '202005.0'
+        - title: Catalog Search
+          url: /docs/scos/dev/glue-api-guides/catalog-search.html
+          include_versions:
+            - '202005.0'
+        - title: Retrieving Customer's Order History
+          url: /docs/scos/dev/glue-api-guides/retrieving-cust.html
+          include_versions:
+            - '202005.0'
+        - title: Configuring Outdated Refresh Token Life Time
+          url: /docs/scos/dev/glue-api-guides/configuring-out.html
+          include_versions:
+            - '202005.0'
+        - title: Checking Out Purchases and Getting Checkout Data
+          url: /docs/scos/dev/glue-api-guides/checking-out-pu.html
+          include_versions:
+            - '202005.0'
+        - title: Managing products
+          nested:
+            - title: Retrieving and Applying Product Options
+              url: /docs/scos/dev/glue-api-guides/managing-products/retrieving-and-.html
+              include_versions:
+                - '202005.0'
+            - title: Retrieving Alternative Products
+              url: /docs/scos/dev/glue-api-guides/managing-products/retrieving-alte.html
+              include_versions:
+                - '202005.0'
+            - title: Retrieving Product Information
+              url: /docs/scos/dev/glue-api-guides/managing-products/retrieving-prod.html
+              include_versions:
+                - '202005.0'
+            - title: Retrieving Related Products
+              url: /docs/scos/dev/glue-api-guides/managing-products/retrieving-rela.html
+              include_versions:
+                - '202005.0'
+            - title: Retrieving alternative products
+              url: /docs/scos/dev/glue-api-guides/managing-products/retrieving-alte.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+            - title: Retrieving product labels
+              url: /docs/scos/dev/glue-api-guides/managing-products/retrieving-prod.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+            - title: Concrete products
+              nested:
+                - title: Retrieving image sets of concrete products
+                  url: /docs/scos/dev/glue-api-guides/managing-products/concrete-products/retrieving-imag.html
+                  include_versions:
+                    - '202009.0'
+                    - '202108.0'
+                - title: Retrieving concrete product prices
+                  url: /docs/scos/dev/glue-api-guides/managing-products/concrete-products/retrieving-conc-2-.html
+                  include_versions:
+                    - '202009.0'
+                    - '202108.0'
+                - title: Retrieving sales units
+                  url: /docs/scos/dev/glue-api-guides/managing-products/concrete-products/retrieving-sale.html
+                  include_versions:
+                    - '202009.0'
+                    - '202108.0'
+                - title: Retrieving concrete product availability
+                  url: /docs/scos/dev/glue-api-guides/managing-products/concrete-products/retrieving-conc-1-.html
+                  include_versions:
+                    - '202009.0'
+                    - '202108.0'
+                - title: Retrieving concrete products
+                  url: /docs/scos/dev/glue-api-guides/managing-products/concrete-products/retrieving-conc.html
+                  include_versions:
+                    - '202009.0'
+                    - '202108.0'
+            - title: Retrieving bundled products
+              url: /docs/scos/dev/glue-api-guides/managing-products/retrieving-bund.html
+              include_versions:
+                - '202108.0'
+            - title: Retrieving related products
+              url: /docs/scos/dev/glue-api-guides/managing-products/retrieving-rela.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+            - title: Managing availability notifications
+              nested:
+                - title: Managing availability notifications
+                  url: /docs/scos/dev/glue-api-guides/managing-products/managing-availability-notifications/managing-availa.html
+                  include_versions:
+                    - '202108.0'
+                - title: Retrieving subscriptions to availability notifications
+                  url: /docs/scos/dev/glue-api-guides/managing-products/managing-availability-notifications/retrieving-subs.html
+                  include_versions:
+                    - '202108.0'
+            - title: Managing product ratings and reviews
+              url: /docs/scos/dev/glue-api-guides/managing-products/managing-produc.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+            - title: Retrieving configurable bundle templates
+              url: /docs/scos/dev/glue-api-guides/managing-products/retrieving-conf.html
+              include_versions:
+                - '202108.0'
+            - title: Abstract products
+              nested:
+                - title: Retrieving image sets of abstract products
+                  url: /docs/scos/dev/glue-api-guides/managing-products/abstract-products/retrieving-imag.html
+                  include_versions:
+                    - '202009.0'
+                    - '202108.0'
+                - title: Retrieving abstract product prices
+                  url: /docs/scos/dev/glue-api-guides/managing-products/abstract-products/retrieving-abst.html
+                  include_versions:
+                    - '202009.0'
+                    - '202108.0'
+                - title: Retrieving tax sets
+                  url: /docs/scos/dev/glue-api-guides/managing-products/abstract-products/retrieving-tax-.html
+                  include_versions:
+                    - '202009.0'
+                    - '202108.0'
+        - title: Discounts and Promotions
+          nested:
+            - title: Retrieving Discounts
+              url: /docs/scos/dev/glue-api-guides/discounts-and-promotions/retrieving-disc.html
+              include_versions:
+                - '202005.0'
+            - title: Retrieving Promotional Items
+              url: /docs/scos/dev/glue-api-guides/discounts-and-promotions/retrieving-prom.html
+              include_versions:
+                - '202005.0'
+        - title: Handling Concurrent REST Requests and Caching with Etags
+          url: /docs/scos/dev/glue-api-guides/handling-concur.html
+          include_versions:
+            - '202005.0'
+        - title: B2B Account Management
+          nested:
+            - title: Retrieving Company Role Information
+              url: /docs/scos/dev/glue-api-guides/b2b-account-management/retrieving-comp.html
+              include_versions:
+                - '202005.0'
+            - title: Logging In as Company User
+              url: /docs/scos/dev/glue-api-guides/b2b-account-management/logging-in-as-c.html
+              include_versions:
+                - '202005.0'
+            - title: Retrieving Business Unit Information
+              url: /docs/scos/dev/glue-api-guides/b2b-account-management/retrieving-busi.html
+              include_versions:
+                - '202005.0'
+            - title: B2B Account Management
+              url: /docs/scos/dev/glue-api-guides/b2b-account-management/b2b-account-man.html
+              include_versions:
+                - '202005.0'
+        - title: Using Search Engine Friendly URLs
+          url: /docs/scos/dev/glue-api-guides/using-search-en.html
+          include_versions:
+            - '202005.0'
+        - title: Managing Customers
+          url: /docs/scos/dev/glue-api-guides/managing-custom.html
+          include_versions:
+            - '202005.0'
+        - title: REST API Reference
+          url: /docs/scos/dev/glue-api-guides/rest-api-refere.html
+          include_versions:
+            - '202005.0'
+        - title: Managing Shopping Lists
+          url: /docs/scos/dev/glue-api-guides/managing-shoppi.html
+          include_versions:
+            - '202005.0'
+        - title: Searching the product catalog
+          url: /docs/scos/dev/glue-api-guides/searching-the-p.html
+          include_versions:
+            - '202108.0'
+        - title: Managing wishlists
+          nested:
+            - title: Managing wishlists
+              url: /docs/scos/dev/glue-api-guides/managing-wishlists/managing-wishli.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+        - title: Checking out
+          nested:
+            - title: Checkout workflow
+              url: /docs/scos/dev/glue-api-guides/checking-out/checkout-workfl.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+            - title: Submitting checkout data
+              url: /docs/scos/dev/glue-api-guides/checking-out/submitting-chec.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+            - title: Checking out purchases
+              url: /docs/scos/dev/glue-api-guides/checking-out/checking-out-pu.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+            - title: Updating payment data
+              url: /docs/scos/dev/glue-api-guides/checking-out/updating-paymen.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+        - title: Retrieving navigation trees
+          url: /docs/scos/dev/glue-api-guides/retrieving-navi.html
+          include_versions:
+            - '202009.0'
+            - '202108.0'
+        - title: Retrieving measurement units
+          url: /docs/scos/dev/glue-api-guides/retrieving-meas.html
+          include_versions:
+            - '202009.0'
+            - '202108.0'
+        - title: Managing shopping lists
+          nested:
+            - title: Managing shopping list items
+              url: /docs/scos/dev/glue-api-guides/managing-shopping-lists/managing-shoppi.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+        - title: Retrieving store configuration
+          url: /docs/scos/dev/glue-api-guides/retrieving-stor.html
+          include_versions:
+            - '202009.0'
+            - '202108.0'
+        - title: Managing customers
+          nested:
+            - title: Authenticating as a customer
+              url: /docs/scos/dev/glue-api-guides/managing-customers/authenticating-.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+            - title: Retrieving customer carts
+              url: /docs/scos/dev/glue-api-guides/managing-customers/retrieving-cust.html
+              include_versions:
+                - '202108.0'
+            - title: Confirming customer registration
+              url: /docs/scos/dev/glue-api-guides/managing-customers/confirming-cust.html
+              include_versions:
+                - '202108.0'
+            - title: Managing customer addresses
+              url: /docs/scos/dev/glue-api-guides/managing-customers/managing-custom.html
+              include_versions:
+                - '202108.0'
+            - title: Customer password
+              url: /docs/scos/dev/glue-api-guides/managing-customers/customer-passwo.html
+              include_versions:
+                - '202009.0'
+            - title: Managing customer authentication tokens
+              url: /docs/scos/dev/glue-api-guides/managing-customers/managing-custom.html
+              include_versions:
+                - '202009.0'
+        - title: Deleting expired refresh tokens
+          url: /docs/scos/dev/glue-api-guides/deleting-expire.html
+          include_versions:
+            - '202009.0'
+            - '202108.0'
+        - title: Resolving search engine friendly URLs
+          url: /docs/scos/dev/glue-api-guides/resolving-searc.html
+          include_versions:
+            - '202009.0'
+            - '202108.0'
+        - title: Retrieving autocomplete and search suggestions
+          url: /docs/scos/dev/glue-api-guides/retrieving-auto.html
+          include_versions:
+            - '202108.0'
+        - title: Retrieving content items
+          nested:
+            - title: Retrieving banner content items
+              url: /docs/scos/dev/glue-api-guides/retrieving-content-items/retrieving-bann.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+            - title: Retrieving abstract product list content items
+              url: /docs/scos/dev/glue-api-guides/retrieving-content-items/retireving-abst.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+        - title: Authentication and authorization
+          url: /docs/scos/dev/glue-api-guides/authentication-.html
+          include_versions:
+            - '202009.0'
+            - '202108.0'
+        - title: Managing returns
+          nested:
+            - title: Managing the returns
+              url: /docs/scos/dev/glue-api-guides/managing-returns/managing-the-re.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+            - title: Retrieving return reasons
+              url: /docs/scos/dev/glue-api-guides/managing-returns/retrieving-retu.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+        - title: Managing agent assists
+          nested:
+            - title: Managing agent assist authentication tokens
+              url: /docs/scos/dev/glue-api-guides/managing-agent-assists/managing-agent-.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+            - title: Searching by customers as an agent assist
+              url: /docs/scos/dev/glue-api-guides/managing-agent-assists/searching-by-cu.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+            - title: Authenticating as an agent assist
+              url: /docs/scos/dev/glue-api-guides/managing-agent-assists/authenticating-.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+            - title: Impersonating customers as an agent assist
+              url: /docs/scos/dev/glue-api-guides/managing-agent-assists/impersonating-c.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+        - title: Reference information- GlueApplication errors
+          url: /docs/scos/dev/glue-api-guides/reference-infor.html
+          include_versions:
+            - '202009.0'
+            - '202108.0'
+        - title: Retrieving orders
+          url: /docs/scos/dev/glue-api-guides/retrieving-orde.html
+          include_versions:
+            - '202009.0'
+            - '202108.0'
+        - title: Retrieving categories
+          nested:
+            - title: Retrieving category trees
+              url: /docs/scos/dev/glue-api-guides/retrieving-categories/retrieving-cate.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+        - title: Handling concurrent REST requests and caching with entity tags
+          url: /docs/scos/dev/glue-api-guides/handling-concur.html
+          include_versions:
+            - '202009.0'
+            - '202108.0'
+        - title: Retrieving promotional items
+          url: /docs/scos/dev/glue-api-guides/retrieving-prom.html
+          include_versions:
+            - '202009.0'
+            - '202108.0'
+        - title: Retrieving protected resources
+          url: /docs/scos/dev/glue-api-guides/retrieving-prot.html
+          include_versions:
+            - '202009.0'
+            - '202108.0'
+        - title: Managing B2B account
+          nested:
+            - title: Managing company user authentication tokens
+              url: /docs/scos/dev/glue-api-guides/managing-b2b-account/managing-compan.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+            - title: Authenticating as a company user
+              url: /docs/scos/dev/glue-api-guides/managing-b2b-account/authenticating-.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+            - title: Searching by company users
+              url: /docs/scos/dev/glue-api-guides/managing-b2b-account/searching-by-co.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+            - title: Retrieving companies
+              url: /docs/scos/dev/glue-api-guides/managing-b2b-account/retrieving-comp.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+            - title: Retrieving business unit addresses
+              url: /docs/scos/dev/glue-api-guides/managing-b2b-account/retrieving-busi.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+        - title: REST API reference
+          url: /docs/scos/dev/glue-api-guides/rest-api-refere.html
+          include_versions:
+            - '202009.0'
+            - '202108.0'
+        - title: Retrieving CMS pages
+          url: /docs/scos/dev/glue-api-guides/retrieving-cms-.html
+          include_versions:
+            - '202108.0'
+        - title: Retrieving suggestions for auto-completion and search
+          url: /docs/scos/dev/glue-api-guides/retrieving-sugg.html
+          include_versions:
+            - '202009.0'
+        - title: Catalog search
+          url: /docs/scos/dev/glue-api-guides/catalog-search.html
+          include_versions:
+            - '202009.0'
+    - title: SDK
+      nested:
+        - title: Data export
+          url: /docs/scos/dev/sdk/data-export.html
+          include_versions:
+            - '202009.0'
+            - '202108.0'
+        - title: Zed API
+          nested:
+            - title: Zed API CRUD functionality
+              url: /docs/scos/dev/sdk/zed-api/zed-api-crud-fu.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+            - title: Zed API processor stack
+              url: /docs/scos/dev/sdk/zed-api/zed-api-process.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+            - title: Zed API (Beta)
+              url: /docs/scos/dev/sdk/zed-api/zed-api-beta.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+            - title: Zed API configuration
+              url: /docs/scos/dev/sdk/zed-api/zed-api-config.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+            - title: Zed API project implementation
+              url: /docs/scos/dev/sdk/zed-api/zed-api-project.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+            - title: Zed API resources
+              url: /docs/scos/dev/sdk/zed-api/zed-api-resourc.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+        - title: Cronjob scheduling
+          url: /docs/scos/dev/sdk/cronjob-schedul.html
+          include_versions:
+            - '202009.0'
+            - '202108.0'
+        - title: Twig and TwigExtension
+          url: /docs/scos/dev/sdk/twig-and-twig-e.html
+          include_versions:
+            - '202009.0'
+            - '202108.0'
+        - title: 'Development virtual machine, docker containers & console'
+          url: /docs/scos/dev/sdk/devvm.html
+          include_versions:
+            - '202009.0'
+            - '202108.0'
+        - title: Data import
+          url: /docs/scos/dev/sdk/importer.html
+          include_versions:
+            - '202009.0'
+            - '202108.0'
+        - title: Development tools
+          nested:
+            - title: Tooling config file
+              url: /docs/scos/dev/sdk/development-tools/tooling-config-.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+            - title: Code sniffer
+              url: /docs/scos/dev/sdk/development-tools/code-sniffer.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+            - title: Performance audit tool- Benchmark
+              url: /docs/scos/dev/sdk/development-tools/performance-aud.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+            - title: PHPStan
+              url: /docs/scos/dev/sdk/development-tools/phpstan.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+            - title: Spryk code generator
+              url: /docs/scos/dev/sdk/development-tools/spryk.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+            - title: TS linter
+              url: /docs/scos/dev/sdk/development-tools/ts-linter.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+            - title: Formatter
+              url: /docs/scos/dev/sdk/development-tools/formatter.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+            - title: SCSS linter
+              url: /docs/scos/dev/sdk/development-tools/scss-linter.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+            - title: Static Security Checker
+              url: /docs/scos/dev/sdk/development-tools/static-security.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+            - title: Architecture sniffer
+              url: /docs/scos/dev/sdk/development-tools/architecture-sn.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+        - title: Development
+          url: /docs/scos/dev/sdk/development.html
+          include_versions:
+            - '202009.0'
+            - '202108.0'
+    - title: Tutorials and HowTos
+      nested:
+        - title: About Tutorials
+          url: /docs/scos/dev/tutorials-and-howtos/about-tutorials.html
+          include_versions:
+            - '202009.0'
+            - '202108.0'
+        - title: Introduction Tutorials
+          nested:
+            - title: Tutorial - Checkout and Step Engine - Spryker Commerce OS
+              url: /docs/scos/dev/tutorials-and-howtos/introduction-tutorials/t-checkout-and-.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+            - title: Tutorial - Architectural Walkthrough - Spryker Commerce OS
+              url: /docs/scos/dev/tutorials-and-howtos/introduction-tutorials/tutorial-archit.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+            - title: Tutorial - Testing and TDD - Spryker Commerce OS
+              url: /docs/scos/dev/tutorials-and-howtos/introduction-tutorials/t-testing-tdd-s.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+            - title: Tutorial - Handling New Types of Entity URLs - Legacy Demoshop
+              url: /docs/scos/dev/tutorials-and-howtos/introduction-tutorials/url-handling-ne.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+            - title: Tutorial - Different Sores Different Logic - Landing Pages -
+                Spryker Commerce OS
+              url: /docs/scos/dev/tutorials-and-howtos/introduction-tutorials/t-different-sto.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+            - title: Introduction Tutorials
+              url: /docs/scos/dev/tutorials-and-howtos/introduction-tutorials/introduction-tu.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+            - title: Tutorial - Sending an email
+              url: /docs/scos/dev/tutorials-and-howtos/introduction-tutorials/sending-an-emai.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+            - title: Glue API
+              nested:
+                - title: Implementing a REST API Resource
+                  url: /docs/scos/dev/tutorials-and-howtos/introduction-tutorials/glue-api/implementing-re.html
+                  include_versions:
+                    - '202009.0'
+                    - '202108.0'
+                - title: Validating REST request format
+                  url: /docs/scos/dev/tutorials-and-howtos/introduction-tutorials/glue-api/validating-rest.html
+                  include_versions:
+                    - '202009.0'
+                    - '202108.0'
+                - title: Glue API Tutorials
+                  url: /docs/scos/dev/tutorials-and-howtos/introduction-tutorials/glue-api/glue-api-tutori.html
+                  include_versions:
+                    - '202009.0'
+                    - '202108.0'
+                - title: Versioning REST API Resources
+                  url: /docs/scos/dev/tutorials-and-howtos/introduction-tutorials/glue-api/versioning-rest.html
+                  include_versions:
+                    - '202009.0'
+                    - '202108.0'
+                - title: Documenting GLUE API Resources
+                  url: /docs/scos/dev/tutorials-and-howtos/introduction-tutorials/glue-api/documenting-glu.html
+                  include_versions:
+                    - '202009.0'
+                    - '202108.0'
+                - title: Extending a REST API Resource
+                  url: /docs/scos/dev/tutorials-and-howtos/introduction-tutorials/glue-api/extending-a-res.html
+                  include_versions:
+                    - '202009.0'
+                    - '202108.0'
+            - title: Tutorial - Content and Search - Personalized Catalog Pages -
+                Spryker Commerce OS
+              url: /docs/scos/dev/tutorials-and-howtos/introduction-tutorials/t-content-searc.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+            - title: Tutorial - Integrating any search engine into a project
+              url: /docs/scos/dev/tutorials-and-howtos/introduction-tutorials/tutorial-integr.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+            - title: Tutorial - Content and Search - Attribute-Cart-Based Catalog
+                Personalization - Spryker Commerce OS
+              nested:
+                - title: Tutorial - Content and Search - Attribute-Cart-Based Catalog
+                    Personalization - Spryker Commerce OS
+                  url: /docs/scos/dev/tutorials-and-howtos/introduction-tutorials/tutorial-content-and-search-attribute-cart-based-catalog-personalization-spryker-commerce-os/t-content-searc.html
+                  include_versions:
+                    - '202009.0'
+                    - '202108.0'
+                - title: Tutorial - Boosting Cart Based Search
+                  url: /docs/scos/dev/tutorials-and-howtos/introduction-tutorials/tutorial-content-and-search-attribute-cart-based-catalog-personalization-spryker-commerce-os/boosting-cart-b.html
+                  include_versions:
+                    - '202009.0'
+                    - '202108.0'
+            - title: Tutorial - CMS
+              url: /docs/scos/dev/tutorials-and-howtos/introduction-tutorials/t-cms.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+            - title: Tutorial - Hello World - Spryker Commerce OS
+              url: /docs/scos/dev/tutorials-and-howtos/introduction-tutorials/tutorial-hello-.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+        - title: Advanced Tutorials
+          nested:
+            - title: Tutorial- Product
+              url: /docs/scos/dev/tutorials-and-howtos/advanced-tutorials/t-product-chall.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+            - title: Tutorial - New Relic Monitoring
+              url: /docs/scos/dev/tutorials-and-howtos/advanced-tutorials/t-new-relic-mon.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+            - title: Tutorial - Creating a Table View
+              url: /docs/scos/dev/tutorials-and-howtos/advanced-tutorials/t-create-table-.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+            - title: Tutorial - Database Transaction Handling
+              url: /docs/scos/dev/tutorials-and-howtos/advanced-tutorials/t-database-tran.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+            - title: Tutorial - Using Translations
+              url: /docs/scos/dev/tutorials-and-howtos/advanced-tutorials/t-using-transla.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+            - title: Tutorial - Zed Rest API
+              url: /docs/scos/dev/tutorials-and-howtos/advanced-tutorials/t-zed-rest-api.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+            - title: Tutorial - How the "define" Twig Tag is Working
+              url: /docs/scos/dev/tutorials-and-howtos/advanced-tutorials/tutorial-how-de.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+            - title: Tutorial - Customer Import
+              url: /docs/scos/dev/tutorials-and-howtos/advanced-tutorials/t-customer-impo.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+            - title: Glue API
+              nested:
+                - title: Tutorial - Interacting with Third Party Payment Providers
+                    via Glue API
+                  url: /docs/scos/dev/tutorials-and-howtos/advanced-tutorials/glue-api/t-interacting-w.html
+                  include_versions:
+                    - '202009.0'
+                    - '202108.0'
+                - title: B2C API React Example
+                  nested:
+                    - title: B2C API React Example
+                      url: /docs/scos/dev/tutorials-and-howtos/advanced-tutorials/glue-api/b2c-api-react-example/b2c-api-react-e.html
+                      include_versions:
+                        - '202009.0'
+                        - '202108.0'
+            - title: Tutorial - Twig extensions
+              url: /docs/scos/dev/tutorials-and-howtos/advanced-tutorials/t-twig-extensio.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+            - title: Advanced Tutorials
+              url: /docs/scos/dev/tutorials-and-howtos/advanced-tutorials/advanced-tutori.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+            - title: Tutorial - Replacing a default data importer with the queue data
+                importer
+              url: /docs/scos/dev/tutorials-and-howtos/advanced-tutorials/tutorial-replac.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+            - title: Tutorial - Calculator Plugin
+              url: /docs/scos/dev/tutorials-and-howtos/advanced-tutorials/t-calculator-pl.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+            - title: Tutorial - Console Commands
+              url: /docs/scos/dev/tutorials-and-howtos/advanced-tutorials/t-console-comma.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+            - title: Tutorial - Managing glossary keys
+              url: /docs/scos/dev/tutorials-and-howtos/advanced-tutorials/tutorial-managi.html
+              include_versions:
+                - '202108.0'
+            - title: Tutorial - Internationalization
+              url: /docs/scos/dev/tutorials-and-howtos/advanced-tutorials/t-international.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+            - title: Tutorial - Implementing Widgets and Widget Plugins
+              url: /docs/scos/dev/tutorials-and-howtos/advanced-tutorials/t-widgets-widge.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+        - title: HowTos
+          nested:
+            - title: HowTo - Force HTTPS
+              url: /docs/scos/dev/tutorials-and-howtos/howtos/ht-force-https.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+            - title: HowTo - Set up Stores with Multiple Locales
+              url: /docs/scos/dev/tutorials-and-howtos/howtos/ht-setup-stores.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+            - title: HowTo - Build Your Own Product Relation Type
+              url: /docs/scos/dev/tutorials-and-howtos/howtos/ht-build-produc.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+            - title: HowTo - Change the Default Behavior of Event Triggering in the
+                AvailabilityStorage Module
+              url: /docs/scos/dev/tutorials-and-howtos/howtos/ht-change-defau.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+            - title: HowTo - Notify About Unsupported Browsers
+              url: /docs/scos/dev/tutorials-and-howtos/howtos/howto-notify-ab.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+            - title: HowTo - Create and Register a Mail Provider
+              url: /docs/scos/dev/tutorials-and-howtos/howtos/ht-create-regis.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+            - title: HowTo - Define the maximum size of content fields
+              url: /docs/scos/dev/tutorials-and-howtos/howtos/howto-define-th.html
+              include_versions:
+                - '202108.0'
+            - title: Feature HowTos
+              nested:
+                - title: HowTo - Use Blocks
+                  url: /docs/scos/dev/tutorials-and-howtos/howtos/feature-howtos/ht-use-cms-bloc.html
+                  include_versions:
+                    - '202009.0'
+                    - '202108.0'
+                - title: Feature HowTos
+                  url: /docs/scos/dev/tutorials-and-howtos/howtos/feature-howtos/about-feature-h.html
+                  include_versions:
+                    - '202009.0'
+                    - '202108.0'
+                - title: Data Imports
+                  nested:
+                    - title: HowTo - Import Delivery Methods Linked to Store
+                      url: /docs/scos/dev/tutorials-and-howtos/howtos/feature-howtos/data-imports/ht-import-deliv.html
+                      include_versions:
+                        - '202009.0'
+                        - '202108.0'
+                    - title: HowTo - Import Packaging Units
+                      url: /docs/scos/dev/tutorials-and-howtos/howtos/feature-howtos/data-imports/howto-import-pa.html
+                      include_versions:
+                        - '202009.0'
+                        - '202108.0'
+                    - title: HowTo - Import Warehouse Data
+                      url: /docs/scos/dev/tutorials-and-howtos/howtos/feature-howtos/data-imports/ht-import-wareh.html
+                      include_versions:
+                        - '202009.0'
+                        - '202108.0'
+                    - title: HowTo - Import Payment Method Store Relation Data
+                      url: /docs/scos/dev/tutorials-and-howtos/howtos/feature-howtos/data-imports/ht-import-payme.html
+                      include_versions:
+                        - '202009.0'
+                    - title: HowTo - Import Scheduled Prices
+                      url: /docs/scos/dev/tutorials-and-howtos/howtos/feature-howtos/data-imports/ht-import-sched.html
+                      include_versions:
+                        - '202009.0'
+                - title: HowTo - Configure the Product Reviews
+                  url: /docs/scos/dev/tutorials-and-howtos/howtos/feature-howtos/ht-product-revi.html
+                  include_versions:
+                    - '202009.0'
+                    - '202108.0'
+                - title: HowTo - Set Number of Days for a Return Policy
+                  url: /docs/scos/dev/tutorials-and-howtos/howtos/feature-howtos/howto-set-numbe.html
+                  include_versions:
+                    - '202009.0'
+                    - '202108.0'
+                - title: HowTo - Implement Customer Approval Process Based on a
+                    Generic State Machine
+                  url: /docs/scos/dev/tutorials-and-howtos/howtos/feature-howtos/t-implement-cus.html
+                  include_versions:
+                    - '202009.0'
+                    - '202108.0'
+                - title: HowTo - Disable Split Delivery in Yves Interface
+                  url: /docs/scos/dev/tutorials-and-howtos/howtos/feature-howtos/ht-disable-spli.html
+                  include_versions:
+                    - '202009.0'
+                    - '202108.0'
+                - title: HowTo - Generate a Token for Login
+                  url: /docs/scos/dev/tutorials-and-howtos/howtos/feature-howtos/howto-generate-.html
+                  include_versions:
+                    - '202009.0'
+                    - '202108.0'
+                - title: HowTo - Schedule Cron Job for Scheduled Prices
+                  url: /docs/scos/dev/tutorials-and-howtos/howtos/feature-howtos/ht-schedule-cro.html
+                  include_versions:
+                    - '202009.0'
+                    - '202108.0'
+                - title: HowTo -  Render Configurable Bundle Templates in the
+                    Storefront
+                  url: /docs/scos/dev/tutorials-and-howtos/howtos/feature-howtos/howto-rendering.html
+                  include_versions:
+                    - '202009.0'
+                    - '202108.0'
+                - title: HowTo - Create Discounts Based on Shipment
+                  url: /docs/scos/dev/tutorials-and-howtos/howtos/feature-howtos/ht-activate-a-d.html
+                  include_versions:
+                    - '202009.0'
+                    - '202108.0'
+                - title: HowTo - Emailing Invoices Using BCC
+                  url: /docs/scos/dev/tutorials-and-howtos/howtos/feature-howtos/howto-emailing-.html
+                  include_versions:
+                    - '202009.0'
+                    - '202108.0'
+                - title: CMS
+                  nested:
+                    - title: HowTo - create a custom content item
+                      url: /docs/scos/dev/tutorials-and-howtos/howtos/feature-howtos/cms/howto-create-a-.html
+                      include_versions:
+                        - '202108.0'
+                    - title: HowTo - Create CMS Templates
+                      url: /docs/scos/dev/tutorials-and-howtos/howtos/feature-howtos/cms/ht-create-cms-t.html
+                      include_versions:
+                        - '202009.0'
+                        - '202108.0'
+                    - title: HowTo - Create a Content Item
+                      url: /docs/scos/dev/tutorials-and-howtos/howtos/feature-howtos/cms/howto-create-a-.html
+                      include_versions:
+                        - '202009.0'
+                - title: HowTo - Display Product Groups by Color on the Storefront
+                  url: /docs/scos/dev/tutorials-and-howtos/howtos/feature-howtos/howto-display-p.html
+                  include_versions:
+                    - '202009.0'
+                    - '202108.0'
+                - title: HowTo - define if a cart should be deleted after placing an
+                    order
+                  url: /docs/scos/dev/tutorials-and-howtos/howtos/feature-howtos/howto-define-if.html
+                  include_versions:
+                    - '202108.0'
+                - title: HowTo - Display Custom Names for Order Item States on the
+                    Storefront
+                  url: /docs/scos/dev/tutorials-and-howtos/howtos/feature-howtos/howto-display-c.html
+                  include_versions:
+                    - '202009.0'
+                    - '202108.0'
+                - title: HowTo - Manage a big number of categories
+                  url: /docs/scos/dev/tutorials-and-howtos/howtos/feature-howtos/ht-manage-a-big.html
+                  include_versions:
+                    - '202009.0'
+                    - '202108.0'
+                - title: HowTo - Make a Product Searchable and Shown on the
+                    Storefront
+                  url: /docs/scos/dev/tutorials-and-howtos/howtos/feature-howtos/ht-make-product.html
+                  include_versions:
+                    - '202009.0'
+                    - '202108.0'
+                - title: HowTo - Clean or Duplicate a Cart after an Order
+                  url: /docs/scos/dev/tutorials-and-howtos/howtos/feature-howtos/howto-clean-or-.html
+                  include_versions:
+                    - '202009.0'
+            - title: HowTo — Set up multiple stores
+              url: /docs/scos/dev/tutorials-and-howtos/howtos/howto-set-up-mu.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+            - title: HowTo - Decrease the memory usage of Spryker with Docker on WSL2
+              url: /docs/scos/dev/tutorials-and-howtos/howtos/howto-decrease-.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+            - title: HowTo - Handle Case Sensitive File-System on Mac OS
+              url: /docs/scos/dev/tutorials-and-howtos/howtos/ht-case-sensiti.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+            - title: HowTo - Install Spryker in AWS Environment
+              url: /docs/scos/dev/tutorials-and-howtos/howtos/ht-install-spry.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+            - title: HowTo - Integrate and Use Precise Decimal Numbers
+              url: /docs/scos/dev/tutorials-and-howtos/howtos/ht-integrate-an.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+            - title: HowTo - Create and Register a MailTypePlugin
+              url: /docs/scos/dev/tutorials-and-howtos/howtos/ht-mail-create-.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+            - title: HowTo - Get Ready for VAT (tax) Changes in Germany
+              url: /docs/scos/dev/tutorials-and-howtos/howtos/howto-get-ready.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+            - title: HowTo - Handle graceful shutdown
+              url: /docs/scos/dev/tutorials-and-howtos/howtos/howto-handle-gr.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+            - title: HowTo - Set up Spryker with MySQL
+              url: /docs/scos/dev/tutorials-and-howtos/howtos/ht-setup-spryke.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+            - title: HowTo — Configure basic htaccess authentication
+              url: /docs/scos/dev/tutorials-and-howtos/howtos/howto-configure.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+            - title: HowTo - Handle twenty five million prices in Spryker Commerce OS
+              url: /docs/scos/dev/tutorials-and-howtos/howtos/howto-handle-tw.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+            - title: HowTo - Product Data from Import to Front-End View
+              url: /docs/scos/dev/tutorials-and-howtos/howtos/ht-product-data.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+            - title: HowTo - Enable guest checkout in B2B Demo Shop
+              url: /docs/scos/dev/tutorials-and-howtos/howtos/howto-enable-gu.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+            - title: HowTo - Add additional countries to Spryker checkout
+              url: /docs/scos/dev/tutorials-and-howtos/howtos/howto-add-addit.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+            - title: HowTo - Add a New Shipment Method 2.0
+              url: /docs/scos/dev/tutorials-and-howtos/howtos/ht-add-new-ship.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+            - title: HowTo - Set up custom response headers on project level
+              url: /docs/scos/dev/tutorials-and-howtos/howtos/howto-set-up-cu.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+            - title: HowTo - Replace Spryker Module Dependencies
+              url: /docs/scos/dev/tutorials-and-howtos/howtos/ht-replace-bund.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+            - title: HowTo - Replace key-value storage with database
+              url: /docs/scos/dev/tutorials-and-howtos/howtos/howto-replace-k.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+            - title: HowTo - Customize HTTP Headers in AJAX Request
+              url: /docs/scos/dev/tutorials-and-howtos/howtos/ht-customize-ht.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+            - title: HowTo - Reset a Docker environment
+              url: /docs/scos/dev/tutorials-and-howtos/howtos/howto-reset-a-d.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+            - title: HowTo - Hydrate Payment Methods for an Order
+              url: /docs/scos/dev/tutorials-and-howtos/howtos/ht-hydrate-paym.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+            - title: HowTo - Set up Database Connections
+              url: /docs/scos/dev/tutorials-and-howtos/howtos/ht-setup-databa.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+            - title: HowTo - Allow Zed CSS/JS on a project
+              url: /docs/scos/dev/tutorials-and-howtos/howtos/howto-allow-zed.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+            - title: Glue API HowTos
+              nested:
+                - title: Glue API HowTos
+                  url: /docs/scos/dev/tutorials-and-howtos/howtos/glue-api-howtos/about-glue-api-.html
+                  include_versions:
+                    - '202009.0'
+                    - '202108.0'
+                - title: Configuring Glue for cross-origin requests
+                  url: /docs/scos/dev/tutorials-and-howtos/howtos/glue-api-howtos/ht-configuring-.html
+                  include_versions:
+                    - '202009.0'
+                    - '202108.0'
+                - title: Managing customer access to Glue API resources
+                  url: /docs/scos/dev/tutorials-and-howtos/howtos/glue-api-howtos/managing-custom.html
+                  include_versions:
+                    - '202108.0'
+                - title: Managing Customer Access to API Resources
+                  url: /docs/scos/dev/tutorials-and-howtos/howtos/glue-api-howtos/managing-custom.html
+                  include_versions:
+                    - '202009.0'
+            - title: HowTo — enable SFTP for Flysystem
+              url: /docs/scos/dev/tutorials-and-howtos/howtos/howto-enable-sf.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+            - title: HowTo - Create Personalized Prices
+              url: /docs/scos/dev/tutorials-and-howtos/howtos/ht-create-perso.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+            - title: About HowTos
+              url: /docs/scos/dev/tutorials-and-howtos/howtos/how-tos.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+            - title: HowTo - Define maximum size of content fields
+              url: /docs/scos/dev/tutorials-and-howtos/howtos/content-fields-.html
+              include_versions:
+                - '202009.0'
+    - title: Tutorials
+      nested:
+        - title: Advanced
+          nested:
+            - title: Tutorial- Product Challenge Solution
+              url: /docs/scos/dev/tutorials/advanced/t-product-chall.html
+              include_versions:
+                - '201907.0'
+                - '202001.0'
+                - '202005.0'
+            - title: Tutorial - New Relic Monitoring
+              url: /docs/scos/dev/tutorials/advanced/t-new-relic-mon.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+                - '201907.0'
+                - '202001.0'
+                - '202005.0'
+            - title: Tutorial - Creating a Table View
+              url: /docs/scos/dev/tutorials/advanced/t-create-table-.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+                - '201907.0'
+                - '202001.0'
+                - '202005.0'
+            - title: Tutorial - Database Transaction Handling
+              url: /docs/scos/dev/tutorials/advanced/t-database-tran.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+                - '201907.0'
+                - '202001.0'
+                - '202005.0'
+            - title: Tutorial - Using Translations
+              url: /docs/scos/dev/tutorials/advanced/t-using-transla.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+                - '201907.0'
+                - '202001.0'
+                - '202005.0'
+            - title: Tutorial - Zed Rest API
+              url: /docs/scos/dev/tutorials/advanced/t-zed-rest-api.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+                - '201907.0'
+                - '202001.0'
+                - '202005.0'
+            - title: Tutorial - How the "define" Twig Tag is Working
+              url: /docs/scos/dev/tutorials/advanced/tutorial-how-de.html
+              include_versions:
+                - '202001.0'
+                - '202005.0'
+            - title: Tutorial - Customer Import
+              url: /docs/scos/dev/tutorials/advanced/t-customer-impo.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+                - '201907.0'
+                - '202001.0'
+                - '202005.0'
+            - title: Glue API
+              nested:
+                - title: Tutorial - Interacting with Third Party Payment Providers
+                    via Glue API
+                  url: /docs/scos/dev/tutorials/advanced/glue-api/t-interacting-w.html
+                  include_versions:
+                    - '201907.0'
+                    - '202001.0'
+                    - '202005.0'
+                - title: B2C API React Example
+                  nested:
+                    - title: B2C API React Example
+                      url: /docs/scos/dev/tutorials/advanced/glue-api/b2c-api-react-example/b2c-api-react-e.html
+                      include_versions:
+                        - '202005.0'
+                - title: Advanced Glue API Tutorials
+                  url: /docs/scos/dev/tutorials/advanced/glue-api/advanced-glue-a.html
+                  include_versions:
+                    - '201907.0'
+            - title: Tutorial - Twig Extensions
+              url: /docs/scos/dev/tutorials/advanced/t-twig-extensio.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+                - '201907.0'
+                - '202001.0'
+            - title: Advanced Tutorials
+              url: /docs/scos/dev/tutorials/advanced/advanced-tutori.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+                - '201907.0'
+                - '202001.0'
+                - '202005.0'
+            - title: Tutorial - Calculator Plugin
+              url: /docs/scos/dev/tutorials/advanced/t-calculator-pl.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+                - '201907.0'
+                - '202001.0'
+                - '202005.0'
+            - title: Tutorial - Console Commands
+              url: /docs/scos/dev/tutorials/advanced/t-console-comma.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+                - '201907.0'
+                - '202001.0'
+                - '202005.0'
+            - title: Tutorial - Internationalization
+              url: /docs/scos/dev/tutorials/advanced/t-international.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+                - '201907.0'
+                - '202001.0'
+                - '202005.0'
+            - title: Tutorial - Implementing Widgets and Widget Plugins
+              url: /docs/scos/dev/tutorials/advanced/t-widgets-widge.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+                - '201907.0'
+                - '202001.0'
+                - '202005.0'
+            - title: Tutorial- Product
+              url: /docs/scos/dev/tutorials/advanced/t-product-chall.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+            - title: Tutorial - Twig extensions
+              url: /docs/scos/dev/tutorials/advanced/t-twig-extensio.html
+              include_versions:
+                - '202005.0'
+        - title: Introduction
+          nested:
+            - title: Tutorial - Checkout and Step Engine - Spryker Commerce OS
+              url: /docs/scos/dev/tutorials/introduction/t-checkout-and-.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+                - '201907.0'
+                - '202001.0'
+                - '202005.0'
+            - title: Tutorial - Architectural Walkthrough - Spryker Commerce OS
+              url: /docs/scos/dev/tutorials/introduction/tutorial-archit.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+                - '201907.0'
+                - '202001.0'
+                - '202005.0'
+            - title: Tutorial - Testing and TDD - Spryker Commerce OS
+              url: /docs/scos/dev/tutorials/introduction/t-testing-tdd-s.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+                - '201907.0'
+                - '202001.0'
+                - '202005.0'
+            - title: Tutorial - Handling New Types of Entity URLs - Legacy Demoshop
+              url: /docs/scos/dev/tutorials/introduction/url-handling-ne.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+                - '201907.0'
+                - '202001.0'
+                - '202005.0'
+            - title: Tutorial - Dynamic Content Page - Legacy Demoshop
+              url: /docs/scos/dev/tutorials/introduction/dynamic-content.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+                - '201907.0'
+                - '202001.0'
+            - title: Tutorial - Different Sores Different Logic - Landing Pages -
+                Spryker Commerce OS
+              url: /docs/scos/dev/tutorials/introduction/t-different-sto.html
+              include_versions:
+                - '202005.0'
+            - title: Introduction Tutorials
+              url: /docs/scos/dev/tutorials/introduction/introduction-tu.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+                - '201907.0'
+                - '202001.0'
+                - '202005.0'
+            - title: Tutorial - Set Up a "Hello World" Queue - Legacy Demoshop
+              url: /docs/scos/dev/tutorials/introduction/setup-hello-wor.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+                - '201907.0'
+                - '202001.0'
+            - title: Tutorial - Handling Data - Publish and Synchronization - Spryker
+                Commerce OS
+              url: /docs/scos/dev/tutorials/introduction/t-handling-data.html
+              include_versions:
+                - '202005.0'
+            - title: Glue API
+              nested:
+                - title: Implementing a REST API Resource
+                  url: /docs/scos/dev/tutorials/introduction/glue-api/implementing-re.html
+                  include_versions:
+                    - '201811.0'
+                    - '201903.0'
+                    - '201907.0'
+                    - '202001.0'
+                    - '202005.0'
+                - title: Validating REST Request Format
+                  url: /docs/scos/dev/tutorials/introduction/glue-api/validating-rest.html
+                  include_versions:
+                    - '201811.0'
+                    - '201903.0'
+                    - '201907.0'
+                    - '202001.0'
+                    - '202005.0'
+                - title: Glue API Tutorials
+                  url: /docs/scos/dev/tutorials/introduction/glue-api/glue-api-tutori.html
+                  include_versions:
+                    - '201811.0'
+                    - '201903.0'
+                    - '201907.0'
+                    - '202001.0'
+                    - '202005.0'
+                - title: Versioning REST API Resources
+                  url: /docs/scos/dev/tutorials/introduction/glue-api/versioning-rest.html
+                  include_versions:
+                    - '201811.0'
+                    - '201903.0'
+                    - '201907.0'
+                    - '202001.0'
+                    - '202005.0'
+                - title: Documenting GLUE API Resources
+                  url: /docs/scos/dev/tutorials/introduction/glue-api/documenting-glu.html
+                  include_versions:
+                    - '201811.0'
+                    - '201903.0'
+                    - '201907.0'
+                    - '202001.0'
+                    - '202005.0'
+                - title: Extending a REST API Resource
+                  url: /docs/scos/dev/tutorials/introduction/glue-api/extending-a-res.html
+                  include_versions:
+                    - '201811.0'
+                    - '201903.0'
+                    - '201907.0'
+                    - '202001.0'
+                    - '202005.0'
+            - title: Tutorial - Content and Search - Personalized Catalog Pages -
+                Spryker Commerce OS
+              url: /docs/scos/dev/tutorials/introduction/t-content-searc.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+                - '201907.0'
+                - '202001.0'
+                - '202005.0'
+            - title: Tutorial - Content and Search - Attribute-Cart-Based Catalog
+                Personalization - Spryker Commerce OS
+              nested:
+                - title: Tutorial - Content and Search - Attribute-Cart-Based Catalog
+                    Personalization - Spryker Commerce OS
+                  url: /docs/scos/dev/tutorials/introduction/tutorial-content-and-search-attribute-cart-based-catalog-personalization-spryker-commerce-os/t-content-searc.html
+                  include_versions:
+                    - '201811.0'
+                    - '201903.0'
+                    - '201907.0'
+                    - '202001.0'
+                    - '202005.0'
+                - title: Tutorial - Boosting Cart Based Search
+                  url: /docs/scos/dev/tutorials/introduction/tutorial-content-and-search-attribute-cart-based-catalog-personalization-spryker-commerce-os/boosting-cart-b.html
+                  include_versions:
+                    - '201811.0'
+                    - '201903.0'
+                    - '201907.0'
+                    - '202001.0'
+                    - '202005.0'
+            - title: Tutorial - Sending a Mail
+              url: /docs/scos/dev/tutorials/introduction/mail-how-to-sen.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+                - '201907.0'
+                - '202001.0'
+                - '202005.0'
+            - title: Tutorial - CMS
+              url: /docs/scos/dev/tutorials/introduction/t-cms.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+                - '201907.0'
+                - '202001.0'
+                - '202005.0'
+            - title: Tutorial - Hello World - Spryker Commerce OS
+              url: /docs/scos/dev/tutorials/introduction/tutorial-hello-.html
+              include_versions:
+                - '202005.0'
+            - title: Tutorial - Architectural Walkthrough - Legacy Demoshop
+              url: /docs/scos/dev/tutorials/introduction/architectural-w.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+                - '201907.0'
+                - '202001.0'
+            - title: Tutorial - Checkout - Legacy Demoshop
+              url: /docs/scos/dev/tutorials/introduction/tutorial-checko.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+                - '201907.0'
+                - '202001.0'
+        - title: About Tutorials
+          url: /docs/scos/dev/tutorials/about-tutorials.html
+          include_versions:
+            - '201811.0'
+            - '201903.0'
+            - '201907.0'
+            - '202001.0'
+            - '202005.0'
+        - title: HowTos
+          nested:
+            - title: HowTo - Force HTTPS
+              url: /docs/scos/dev/tutorials/howtos/ht-force-https.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+                - '201907.0'
+                - '202001.0'
+                - '202005.0'
+            - title: HowTo - Set up Stores with Multiple Locales
+              url: /docs/scos/dev/tutorials/howtos/ht-setup-stores.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+                - '201907.0'
+                - '202001.0'
+                - '202005.0'
+            - title: HowTo - Build Your Own Product Relation Type
+              url: /docs/scos/dev/tutorials/howtos/ht-build-produc.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+                - '201907.0'
+                - '202001.0'
+                - '202005.0'
+            - title: HowTo - Change the Default Behavior of Event Triggering in the
+                AvailabilityStorage Module
+              url: /docs/scos/dev/tutorials/howtos/ht-change-defau.html
+              include_versions:
+                - '202001.0'
+                - '202005.0'
+            - title: HowTo - Notify About Unsupported Browsers
+              url: /docs/scos/dev/tutorials/howtos/howto-notify-ab.html
+              include_versions:
+                - '202001.0'
+                - '202005.0'
+            - title: HowTo - Create and Register a Mail Provider
+              url: /docs/scos/dev/tutorials/howtos/ht-create-regis.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+                - '201907.0'
+                - '202001.0'
+                - '202005.0'
+            - title: Feature HowTos
+              nested:
+                - title: HowTo - Use Blocks
+                  url: /docs/scos/dev/tutorials/howtos/feature-howtos/ht-use-cms-bloc.html
+                  include_versions:
+                    - '201811.0'
+                    - '201903.0'
+                    - '201907.0'
+                    - '202001.0'
+                    - '202005.0'
+                - title: Feature HowTos
+                  url: /docs/scos/dev/tutorials/howtos/feature-howtos/about-feature-h.html
+                  include_versions:
+                    - '201811.0'
+                    - '201903.0'
+                    - '201907.0'
+                    - '202001.0'
+                    - '202005.0'
+                - title: Data Imports
+                  nested:
+                    - title: HowTo - Import Payment Method Store Relation Data
+                      url: /docs/scos/dev/tutorials/howtos/feature-howtos/data-imports/ht-import-payme.html
+                      include_versions:
+                        - '202001.0'
+                        - '202005.0'
+                    - title: HowTo - Import Delivery Methods Linked to Store
+                      url: /docs/scos/dev/tutorials/howtos/feature-howtos/data-imports/ht-import-deliv.html
+                      include_versions:
+                        - '202001.0'
+                        - '202005.0'
+                    - title: HowTo - Import Packaging Units
+                      url: /docs/scos/dev/tutorials/howtos/feature-howtos/data-imports/howto-import-pa.html
+                      include_versions:
+                        - '202001.0'
+                        - '202005.0'
+                    - title: HowTo - Import Scheduled Prices
+                      url: /docs/scos/dev/tutorials/howtos/feature-howtos/data-imports/ht-import-sched.html
+                      include_versions:
+                        - '202001.0'
+                        - '202005.0'
+                    - title: HowTo - Import Warehouse Data
+                      url: /docs/scos/dev/tutorials/howtos/feature-howtos/data-imports/ht-import-wareh.html
+                      include_versions:
+                        - '202001.0'
+                        - '202005.0'
+                - title: HowTo - Configure the Product Reviews
+                  url: /docs/scos/dev/tutorials/howtos/feature-howtos/ht-product-revi.html
+                  include_versions:
+                    - '201811.0'
+                    - '201903.0'
+                    - '201907.0'
+                    - '202001.0'
+                    - '202005.0'
+                - title: HowTo - Implement Customer Approval Process Based on a
+                    Generic State Machine
+                  url: /docs/scos/dev/tutorials/howtos/feature-howtos/t-implement-cus.html
+                  include_versions:
+                    - '202001.0'
+                    - '202005.0'
+                - title: HowTo - Disable Split Delivery in Yves Interface
+                  url: /docs/scos/dev/tutorials/howtos/feature-howtos/ht-disable-spli.html
+                  include_versions:
+                    - '202001.0'
+                    - '202005.0'
+                - title: HowTo - Schedule Cron Job for Scheduled Prices
+                  url: /docs/scos/dev/tutorials/howtos/feature-howtos/ht-schedule-cro.html
+                  include_versions:
+                    - '202001.0'
+                    - '202005.0'
+                - title: HowTo -  Render Configurable Bundle Templates in the
+                    Storefront
+                  url: /docs/scos/dev/tutorials/howtos/feature-howtos/howto-rendering.html
+                  include_versions:
+                    - '202001.0'
+                    - '202005.0'
+                - title: HowTo - Create Discounts Based on Shipment
+                  url: /docs/scos/dev/tutorials/howtos/feature-howtos/ht-activate-a-d.html
+                  include_versions:
+                    - '202001.0'
+                    - '202005.0'
+                - title: CMS
+                  nested:
+                    - title: HowTo - Create a Content Item
+                      url: /docs/scos/dev/tutorials/howtos/feature-howtos/cms/howto-create-a-.html
+                      include_versions:
+                        - '202001.0'
+                        - '202005.0'
+                    - title: HowTo - Create CMS Templates
+                      url: /docs/scos/dev/tutorials/howtos/feature-howtos/cms/ht-create-cms-t.html
+                      include_versions:
+                        - '201811.0'
+                        - '201903.0'
+                        - '201907.0'
+                        - '202001.0'
+                        - '202005.0'
+                    - title: HowTo - Enable CMS Content Widgets Button in the WYSIWYG
+                        Editor
+                      url: /docs/scos/dev/tutorials/howtos/feature-howtos/cms/ht-enable-cms-c.html
+                      include_versions:
+                        - '201907.0'
+                - title: HowTo - Clean or Duplicate a Cart after an Order
+                  url: /docs/scos/dev/tutorials/howtos/feature-howtos/howto-clean-or-.html
+                  include_versions:
+                    - '202001.0'
+                    - '202005.0'
+                - title: HowTo - Manage a Big Number of Categories
+                  url: /docs/scos/dev/tutorials/howtos/feature-howtos/ht-manage-a-big.html
+                  include_versions:
+                    - '201903.0'
+                    - '201907.0'
+                    - '202001.0'
+                    - '202005.0'
+                - title: HowTo - Make a Product Searchable and Shown on the
+                    Storefront
+                  url: /docs/scos/dev/tutorials/howtos/feature-howtos/ht-make-product.html
+                  include_versions:
+                    - '202001.0'
+                    - '202005.0'
+                - title: HowTo - Change the Default Behavior of Event Triggering in
+                    the AvailabilityStorage Module
+                  url: /docs/scos/dev/tutorials/howtos/feature-howtos/ht-change-defau.html
+                  include_versions:
+                    - '201811.0'
+                    - '201903.0'
+                    - '201907.0'
+                - title: HowTo - Define Maximum Size of Content Fields
+                  url: /docs/scos/dev/tutorials/howtos/feature-howtos/content-fields-.html
+                  include_versions:
+                    - '201811.0'
+                    - '201903.0'
+                    - '201907.0'
+                - title: HowTo - Make a Product Searchable and Shown on Yves by URL
+                  url: /docs/scos/dev/tutorials/howtos/feature-howtos/ht-make-product.html
+                  include_versions:
+                    - '201811.0'
+                    - '201903.0'
+                    - '201907.0'
+                - title: HowTo - Set Number of Days for a Return Policy
+                  url: /docs/scos/dev/tutorials/howtos/feature-howtos/howto-set-numbe.html
+                  include_versions:
+                    - '202005.0'
+                - title: HowTo - Display Product Groups by Color on the Storefront
+                  url: /docs/scos/dev/tutorials/howtos/feature-howtos/howto-display-p.html
+                  include_versions:
+                    - '202005.0'
+                - title: HowTo - Import Merchants and Merchant Relations
+                  url: /docs/scos/dev/tutorials/howtos/feature-howtos/howto-import-me.html
+                  include_versions:
+                    - '201903.0'
+                    - '201907.0'
+                - title: HowTo - Configure Separators and Default Number of Rows
+                  url: /docs/scos/dev/tutorials/howtos/feature-howtos/ht-configure-se.html
+                  include_versions:
+                    - '201903.0'
+                    - '201907.0'
+                - title: HowTo - Import Minimum Order Value Data
+                  url: /docs/scos/dev/tutorials/howtos/feature-howtos/ht-import-minim.html
+                  include_versions:
+                    - '201903.0'
+                    - '201907.0'
+                - title: How to Schedule Cron Job for Scheduled Prices
+                  url: /docs/scos/dev/tutorials/howtos/feature-howtos/ht-schedule-cro.html
+                  include_versions:
+                    - '201907.0'
+                - title: HowTo - Disable Accounts Switch for Business on Behalf
+                  url: /docs/scos/dev/tutorials/howtos/feature-howtos/ht-disable-acco.html
+                  include_versions:
+                    - '201907.0'
+                - title: HowTo - Import Scheduled Prices
+                  url: /docs/scos/dev/tutorials/howtos/feature-howtos/ht-import-sched.html
+                  include_versions:
+                    - '201907.0'
+                - title: HowTo - Generate a Token for Login
+                  url: /docs/scos/dev/tutorials/howtos/feature-howtos/ht-generating-t.html
+                  include_versions:
+                    - '201907.0'
+            - title: HowTo - Handle Case Sensitive File-System on Mac OS
+              url: /docs/scos/dev/tutorials/howtos/ht-case-sensiti.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+                - '201907.0'
+                - '202001.0'
+                - '202005.0'
+            - title: HowTo - Install Spryker in AWS Environment
+              url: /docs/scos/dev/tutorials/howtos/ht-install-spry.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+                - '201907.0'
+                - '202001.0'
+                - '202005.0'
+            - title: HowTo - Integrate and Use Precise Decimal Numbers
+              url: /docs/scos/dev/tutorials/howtos/ht-integrate-an.html
+              include_versions:
+                - '202001.0'
+                - '202005.0'
+            - title: HowTo - Create and Register a MailTypePlugin
+              url: /docs/scos/dev/tutorials/howtos/ht-mail-create-.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+                - '201907.0'
+                - '202001.0'
+                - '202005.0'
+            - title: HowTo - Set up Spryker with MySQL
+              url: /docs/scos/dev/tutorials/howtos/ht-setup-spryke.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+                - '201907.0'
+                - '202001.0'
+                - '202005.0'
+            - title: HowTo - Product Data from Import to Front-End View
+              url: /docs/scos/dev/tutorials/howtos/ht-product-data.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+                - '201907.0'
+                - '202001.0'
+                - '202005.0'
+            - title: HowTo - Disable Key-value Storage and use the Database Instead
+              url: /docs/scos/dev/tutorials/howtos/howto-disable-k.html
+              include_versions:
+                - '202001.0'
+                - '202005.0'
+            - title: HowTo - Add a New Shipment Method
+              url: /docs/scos/dev/tutorials/howtos/ht-add-new-ship.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+                - '202001.0'
+            - title: HowTo - Define Maximum Size of Content Fields
+              url: /docs/scos/dev/tutorials/howtos/content-fields-.html
+              include_versions:
+                - '202001.0'
+                - '202005.0'
+            - title: HowTo - Replace Spryker Module Dependencies
+              url: /docs/scos/dev/tutorials/howtos/ht-replace-bund.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+                - '201907.0'
+                - '202001.0'
+                - '202005.0'
+            - title: HowTo - Customize HTTP Headers in AJAX Request
+              url: /docs/scos/dev/tutorials/howtos/ht-customize-ht.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+                - '201907.0'
+                - '202001.0'
+                - '202005.0'
+            - title: HowTo - Hydrate Payment Methods for an Order
+              url: /docs/scos/dev/tutorials/howtos/ht-hydrate-paym.html
+              include_versions:
+                - '202001.0'
+                - '202005.0'
+            - title: HowTo - Set up Database Connections
+              url: /docs/scos/dev/tutorials/howtos/ht-setup-databa.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+                - '201907.0'
+                - '202001.0'
+                - '202005.0'
+            - title: Glue API HowTos
+              nested:
+                - title: Glue API HowTos
+                  url: /docs/scos/dev/tutorials/howtos/glue-api-howtos/about-glue-api-.html
+                  include_versions:
+                    - '201903.0'
+                    - '201907.0'
+                    - '202001.0'
+                    - '202005.0'
+                - title: Configuring Glue for Cross-Origin Requests
+                  url: /docs/scos/dev/tutorials/howtos/glue-api-howtos/ht-configuring-.html
+                  include_versions:
+                    - '201903.0'
+                    - '201907.0'
+                    - '202001.0'
+                    - '202005.0'
+                - title: Managing Customer Access to API Resources
+                  url: /docs/scos/dev/tutorials/howtos/glue-api-howtos/managing-custom.html
+                  include_versions:
+                    - '202001.0'
+                    - '202005.0'
+            - title: HowTo - Create Personalized Prices
+              url: /docs/scos/dev/tutorials/howtos/ht-create-perso.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+                - '201907.0'
+                - '202001.0'
+                - '202005.0'
+            - title: About HowTos
+              url: /docs/scos/dev/tutorials/howtos/how-tos.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+                - '201907.0'
+                - '202001.0'
+                - '202005.0'
+            - title: HowTo - Implement Customer Approval Process Based on a Generic
+                State Machine
+              url: /docs/scos/dev/tutorials/howtos/t-implement-cus.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+                - '201907.0'
+            - title: HowTo - Get Ready for VAT (tax) Changes in Germany
+              url: /docs/scos/dev/tutorials/howtos/howto-get-ready.html
+              include_versions:
+                - '202005.0'
+            - title: HowTo - Add a New Shipment Method 2.0
+              url: /docs/scos/dev/tutorials/howtos/ht-add-new-ship.html
+              include_versions:
+                - '201907.0'
+                - '202005.0'
+            - title: HowTo - Dump Queue Messages
+              url: /docs/scos/dev/tutorials/howtos/ht-dump-queue-m.html
+              include_versions:
+                - '201903.0'
+                - '201907.0'
+            - title: Spryker in Docker HowTos
+              nested:
+                - title: Spryker in Docker HowTos
+                  url: /docs/scos/dev/tutorials/howtos/spryker-in-docker-howtos/about-spryker-i.html
+                  include_versions:
+                    - '201907.0'
+                - title: HowTo - Use Self-Signed SSL Certificates
+                  url: /docs/scos/dev/tutorials/howtos/spryker-in-docker-howtos/ht-use-self-sig.html
+                  include_versions:
+                    - '201907.0'
+            - title: HowTo - Use Queue Data Importer
+              url: /docs/scos/dev/tutorials/howtos/ht-use-queue-da.html
+              include_versions:
+                - '201903.0'
+                - '201907.0'
+            - title: HowTo - Adding a New Tag for Comment
+              url: /docs/scos/dev/tutorials/howtos/ht-adding-new-t.html
+              include_versions:
+                - '201907.0'
+    - title: Migration and integration
+      nested:
+        - title: Feature integration guides
+          nested:
+            - title: Shopping Lists Feature Integration
+              url: /docs/scos/dev/migration-and-integration/feature-integration-guides/shopping-lists-.html
+              include_versions:
+                - '202001.0'
+            - title: Prices per Merchant Relation Feature Integration
+              url: /docs/scos/dev/migration-and-integration/feature-integration-guides/prices-per-merc.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+                - '201907.0'
+                - '202001.0'
+                - '202005.0'
+            - title: Content Items Feature Integration
+              url: /docs/scos/dev/migration-and-integration/feature-integration-guides/content-items-f.html
+              include_versions:
+                - '201907.0'
+                - '202001.0'
+                - '202005.0'
+            - title: Multiple Carts Feature Integration
+              url: /docs/scos/dev/migration-and-integration/feature-integration-guides/multiple-carts-.html
+              include_versions:
+                - '201907.0'
+                - '202001.0'
+            - title: Prices Feature Integration
+              url: /docs/scos/dev/migration-and-integration/feature-integration-guides/prices-feature-.html
+              include_versions:
+                - '201903.0'
+                - '201907.0'
+                - '202001.0'
+                - '202005.0'
+            - title: Company Account Feature Integration
+              url: /docs/scos/dev/migration-and-integration/feature-integration-guides/company-account.html
+              include_versions:
+                - '201903.0'
+                - '201907.0'
+                - '202001.0'
+                - '202005.0'
+            - title: Comments + Order Management Feature Integration
+              url: /docs/scos/dev/migration-and-integration/feature-integration-guides/comments-order-.html
+              include_versions:
+                - '201907.0'
+                - '202001.0'
+                - '202005.0'
+            - title: Quick Order- Shopping Lists Feature Integration
+              url: /docs/scos/dev/migration-and-integration/feature-integration-guides/quick-order-sho.html
+              include_versions:
+                - '201903.0'
+                - '201907.0'
+                - '202001.0'
+            - title: Queue Data Import Feature Integration
+              url: /docs/scos/dev/migration-and-integration/feature-integration-guides/queue-data-impo.html
+              include_versions:
+                - '201903.0'
+                - '201907.0'
+                - '202001.0'
+                - '202005.0'
+            - title: Product Feature Integration
+              url: /docs/scos/dev/migration-and-integration/feature-integration-guides/product-feature.html
+              include_versions:
+                - '201903.0'
+                - '201907.0'
+                - '202001.0'
+                - '202005.0'
+            - title: Template
+              url: /docs/scos/dev/migration-and-integration/feature-integration-guides/template.html
+              include_versions:
+                - '201903.0'
+            - title: Cart Integration
+              url: /docs/scos/dev/migration-and-integration/feature-integration-guides/cart-integratio.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+                - '201907.0'
+                - '202001.0'
+                - '202005.0'
+            - title: Installing the Product CMS Block
+              url: /docs/scos/dev/migration-and-integration/feature-integration-guides/product-block.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+                - '201907.0'
+                - '202001.0'
+                - '202005.0'
+            - title: Product + Cart Feature Integration
+              url: /docs/scos/dev/migration-and-integration/feature-integration-guides/product-cart-fe.html
+              include_versions:
+                - '201907.0'
+                - '202001.0'
+                - '202005.0'
+            - title: Inventory Management Feature Integration
+              url: /docs/scos/dev/migration-and-integration/feature-integration-guides/inventory-manag.html
+              include_versions:
+                - '202001.0'
+                - '202005.0'
+            - title: Merchant Contracts Feature Integration
+              url: /docs/scos/dev/migration-and-integration/feature-integration-guides/merchant-contra.html
+              include_versions:
+                - '201903.0'
+                - '201907.0'
+                - '202001.0'
+                - '202005.0'
+            - title: Custom Order Reference Feature Integration
+              url: /docs/scos/dev/migration-and-integration/feature-integration-guides/custom-order-re.html
+              include_versions:
+                - '202001.0'
+                - '202005.0'
+            - title: Enabling the Content Widget
+              url: /docs/scos/dev/migration-and-integration/feature-integration-guides/enabling-cms-wi.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+                - '201907.0'
+                - '202001.0'
+                - '202005.0'
+            - title: Search Widget for Concrete Products Feature Integration
+              url: /docs/scos/dev/migration-and-integration/feature-integration-guides/search-widget-f.html
+              include_versions:
+                - '201903.0'
+                - '201907.0'
+                - '202001.0'
+                - '202005.0'
+            - title: Cart- Non-Splittable Products Feature Integration
+              url: /docs/scos/dev/migration-and-integration/feature-integration-guides/cart-non-splitt.html
+              include_versions:
+                - '201903.0'
+                - '201907.0'
+                - '202001.0'
+                - '202005.0'
+            - title: Permissions Feature Integration
+              url: /docs/scos/dev/migration-and-integration/feature-integration-guides/permissions-fea.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+                - '201907.0'
+                - '202001.0'
+                - '202005.0'
+            - title: Persistent Cart Sharing Feature Integration
+              url: /docs/scos/dev/migration-and-integration/feature-integration-guides/persistent-cart.html
+              include_versions:
+                - '201907.0'
+                - '202001.0'
+                - '202005.0'
+            - title: CMS Block Widget Feature Integration
+              url: /docs/scos/dev/migration-and-integration/feature-integration-guides/cms-block-widge.html
+              include_versions:
+                - '201903.0'
+                - '201907.0'
+                - '202001.0'
+                - '202005.0'
+            - title: Checkout + Quotation Process Feature Integration
+              url: /docs/scos/dev/migration-and-integration/feature-integration-guides/checkout-quotat.html
+              include_versions:
+                - '201907.0'
+                - '202001.0'
+                - '202005.0'
+            - title: CMS Feature Integration Guide
+              url: /docs/scos/dev/migration-and-integration/feature-integration-guides/cms-feature-int.html
+              include_versions:
+                - '201903.0'
+                - '201907.0'
+                - '202001.0'
+                - '202005.0'
+            - title: Merchant Product Restrictions Feature Integration
+              url: /docs/scos/dev/migration-and-integration/feature-integration-guides/merchant-produc.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+                - '201907.0'
+                - '202001.0'
+                - '202005.0'
+            - title: Product Images + Configurable Bundle Feature Integration
+              url: /docs/scos/dev/migration-and-integration/feature-integration-guides/product-images-.html
+              include_versions:
+                - '202001.0'
+                - '202005.0'
+            - title: Agent Assist Feature Integration
+              url: /docs/scos/dev/migration-and-integration/feature-integration-guides/agent-assist-fe.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+                - '201907.0'
+                - '202001.0'
+                - '202005.0'
+            - title: Back in Stock Notification Feature Integration
+              url: /docs/scos/dev/migration-and-integration/feature-integration-guides/product-is-avai.html
+              include_versions:
+                - '202001.0'
+                - '202005.0'
+            - title: Category Image Feature Integration
+              url: /docs/scos/dev/migration-and-integration/feature-integration-guides/category-image-.html
+              include_versions:
+                - '201903.0'
+                - '201907.0'
+                - '202001.0'
+                - '202005.0'
+            - title: Product Measurement Unit Feature Integration
+              url: /docs/scos/dev/migration-and-integration/feature-integration-guides/product-measure.html
+              include_versions:
+                - '201903.0'
+                - '201907.0'
+                - '202001.0'
+                - '202005.0'
+            - title: Enabling Gift Cards
+              url: /docs/scos/dev/migration-and-integration/feature-integration-guides/enabling-gift-c.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+                - '201907.0'
+                - '202001.0'
+                - '202005.0'
+            - title: Merchant Custom Prices Feature Integration
+              url: /docs/scos/dev/migration-and-integration/feature-integration-guides/merchant-custom.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+                - '201907.0'
+                - '202001.0'
+                - '202005.0'
+            - title: CMS + Product Lists + Catalog Feature Integration
+              url: /docs/scos/dev/migration-and-integration/feature-integration-guides/cms-page-search.html
+              include_versions:
+                - '202001.0'
+                - '202005.0'
+            - title: Product Label Feature Integration
+              url: /docs/scos/dev/migration-and-integration/feature-integration-guides/product-label-f.html
+              include_versions:
+                - '201811.0'
+                - '202001.0'
+            - title: Checkout Workflow Integration Guide
+              url: /docs/scos/dev/migration-and-integration/feature-integration-guides/checkout-workfl.html
+              include_versions:
+                - '201903.0'
+            - title: Glue API
+              nested:
+                - title: Glue API- Payments Feature Integration
+                  url: /docs/scos/dev/migration-and-integration/feature-integration-guides/glue-api/glue-api-paymen.html
+                  include_versions:
+                    - '202001.0'
+                    - '202005.0'
+                - title: Glue API- Cart Feature Integration
+                  url: /docs/scos/dev/migration-and-integration/feature-integration-guides/glue-api/cart-feature-in.html
+                  include_versions:
+                    - '202001.0'
+                    - '202005.0'
+                - title: Glue API- REST Schema Validation Feature Integration
+                  url: /docs/scos/dev/migration-and-integration/feature-integration-guides/glue-api/glue-api-rest-s.html
+                  include_versions:
+                    - '201903.0'
+                    - '201907.0'
+                    - '202001.0'
+                - title: Glue API- Navigation Feature Integration
+                  url: /docs/scos/dev/migration-and-integration/feature-integration-guides/glue-api/glue-api-naviga.html
+                  include_versions:
+                    - '202001.0'
+                    - '202005.0'
+                - title: Glue API- Glue Application Feature Integration
+                  url: /docs/scos/dev/migration-and-integration/feature-integration-guides/glue-api/glue-api-glue-a.html
+                  include_versions:
+                    - '202001.0'
+                    - '202005.0'
+                - title: Glue API- Customer Access Feature Integration
+                  url: /docs/scos/dev/migration-and-integration/feature-integration-guides/glue-api/glue-api-custom.html
+                  include_versions:
+                    - '202001.0'
+                    - '202005.0'
+                - title: Glue API- Products Feature Integration
+                  url: /docs/scos/dev/migration-and-integration/feature-integration-guides/glue-api/glue-api-produc.html
+                  include_versions:
+                    - '202001.0'
+                - title: Glue API- Checkout Feature Integration
+                  url: /docs/scos/dev/migration-and-integration/feature-integration-guides/glue-api/checkout-featur.html
+                  include_versions:
+                    - '202001.0'
+                    - '202005.0'
+                - title: Glue API- Content Items API Feature Integration
+                  url: /docs/scos/dev/migration-and-integration/feature-integration-guides/glue-api/glue-api-conten.html
+                  include_versions:
+                    - '202001.0'
+                    - '202005.0'
+                - title: Glue API- Shopping List Feature Integration - ongoing
+                  url: /docs/scos/dev/migration-and-integration/feature-integration-guides/glue-api/glue-api-shoppi.html
+                  include_versions:
+                    - '202001.0'
+                - title: Glue API Installation and Configuration
+                  url: /docs/scos/dev/migration-and-integration/feature-integration-guides/glue-api/glue-api-instal.html
+                  include_versions:
+                    - '201811.0'
+                    - '201903.0'
+                    - '201907.0'
+                    - '202001.0'
+                    - '202005.0'
+                - title: Glue API- Company Account Feature Integration
+                  url: /docs/scos/dev/migration-and-integration/feature-integration-guides/glue-api/glue-api-compan.html
+                  include_versions:
+                    - '201907.0'
+                    - '202001.0'
+                    - '202005.0'
+                - title: Glue API- Alternative Products API Feature Integration
+                  url: /docs/scos/dev/migration-and-integration/feature-integration-guides/glue-api/alternative-pro.html
+                  include_versions:
+                    - '202001.0'
+                - title: Glue API- Spryker Core Feature Integration
+                  url: /docs/scos/dev/migration-and-integration/feature-integration-guides/glue-api/glue-api-spryke.html
+                  include_versions:
+                    - '202001.0'
+                    - '202005.0'
+                - title: Glue API- Wishlist Feature Integration
+                  url: /docs/scos/dev/migration-and-integration/feature-integration-guides/glue-api/glue-api-wishli.html
+                  include_versions:
+                    - '202001.0'
+                    - '202005.0'
+                - title: Glue API- Category Management Feature Integration
+                  url: /docs/scos/dev/migration-and-integration/feature-integration-guides/glue-api/glue-api-catego.html
+                  include_versions:
+                    - '202001.0'
+                    - '202005.0'
+                - title: Glue API- Catalog Feature Integration
+                  url: /docs/scos/dev/migration-and-integration/feature-integration-guides/glue-api/catalog-api-fea.html
+                  include_versions:
+                    - '202001.0'
+                    - '202005.0'
+                - title: Glue API- Promotions & Discounts Feature Integration
+                  url: /docs/scos/dev/migration-and-integration/feature-integration-guides/glue-api/glue-promotions.html
+                  include_versions:
+                    - '202001.0'
+                    - '202005.0'
+                - title: Product Price API Feature Integration
+                  url: /docs/scos/dev/migration-and-integration/feature-integration-guides/glue-api/product-price-a.html
+                  include_versions:
+                    - '201811.0'
+                - title: Category API Feature Integration
+                  url: /docs/scos/dev/migration-and-integration/feature-integration-guides/glue-api/category-api-fe.html
+                  include_versions:
+                    - '201811.0'
+                    - '201903.0'
+                - title: Product Image Sets API Feature Integration
+                  url: /docs/scos/dev/migration-and-integration/feature-integration-guides/glue-api/product-image-s.html
+                  include_versions:
+                    - '201811.0'
+                - title: Glue Application Feature Integration
+                  url: /docs/scos/dev/migration-and-integration/feature-integration-guides/glue-api/glue-applicatio.html
+                  include_versions:
+                    - '201811.0'
+                    - '201903.0'
+                    - '201907.0'
+                - title: Product Availability Feature Integration
+                  url: /docs/scos/dev/migration-and-integration/feature-integration-guides/glue-api/product-availab.html
+                  include_versions:
+                    - '201811.0'
+                    - '201903.0'
+                    - '201907.0'
+                - title: DocumentationGeneratorRestApi Feature Integration
+                  url: /docs/scos/dev/migration-and-integration/feature-integration-guides/glue-api/documentationre.html
+                  include_versions:
+                    - '201811.0'
+                    - '201903.0'
+                    - '201907.0'
+                - title: Product Labels API Feature Integration
+                  url: /docs/scos/dev/migration-and-integration/feature-integration-guides/glue-api/product-labels-.html
+                  include_versions:
+                    - '201811.0'
+                    - '201903.0'
+                - title: Catalog Search API Feature Integration
+                  url: /docs/scos/dev/migration-and-integration/feature-integration-guides/glue-api/catalog-search-.html
+                  include_versions:
+                    - '201811.0'
+                    - '201903.0'
+                    - '201907.0'
+                - title: Product API Feature Integration
+                  url: /docs/scos/dev/migration-and-integration/feature-integration-guides/glue-api/product-api-fea.html
+                  include_versions:
+                    - '201811.0'
+                    - '201903.0'
+                    - '201907.0'
+                - title: Customer API Feature Integration
+                  url: /docs/scos/dev/migration-and-integration/feature-integration-guides/glue-api/customer-api-fe.html
+                  include_versions:
+                    - '201811.0'
+                    - '201903.0'
+                    - '201907.0'
+                - title: Alternative Products API Feature Integration
+                  url: /docs/scos/dev/migration-and-integration/feature-integration-guides/glue-api/alternative-pro.html
+                  include_versions:
+                    - '201811.0'
+                    - '201903.0'
+                    - '201907.0'
+                - title: Wishlist API Feature Integration
+                  url: /docs/scos/dev/migration-and-integration/feature-integration-guides/glue-api/wishlist-api-fe.html
+                  include_versions:
+                    - '201811.0'
+                    - '201903.0'
+                    - '201907.0'
+                - title: Product Tax Sets API Feature Integration
+                  url: /docs/scos/dev/migration-and-integration/feature-integration-guides/glue-api/product-tax-set.html
+                  include_versions:
+                    - '201811.0'
+                    - '201903.0'
+                - title: Order History API Feature Integration
+                  url: /docs/scos/dev/migration-and-integration/feature-integration-guides/glue-api/order-history-a.html
+                  include_versions:
+                    - '201811.0'
+                    - '201907.0'
+                - title: REST Schema Validation Feature Integration
+                  url: /docs/scos/dev/migration-and-integration/feature-integration-guides/glue-api/rest-schema-val.html
+                  include_versions:
+                    - '201811.0'
+                - title: Glue API- Shipment Feature Integration
+                  url: /docs/scos/dev/migration-and-integration/feature-integration-guides/glue-api/glue-api-shipme.html
+                  include_versions:
+                    - '202005.0'
+                - title: GLUE API- Measurement Units Feature Integration
+                  url: /docs/scos/dev/migration-and-integration/feature-integration-guides/glue-api/glue-api-measur.html
+                  include_versions:
+                    - '202005.0'
+                - title: Glue API- Product Labels Feature Integration
+                  url: /docs/scos/dev/migration-and-integration/feature-integration-guides/glue-api/glue-api-produc.html
+                  include_versions:
+                    - '202005.0'
+                - title: Glue API- Alternative Products Feature Integration
+                  url: /docs/scos/dev/migration-and-integration/feature-integration-guides/glue-api/glue-api-altern.html
+                  include_versions:
+                    - '202005.0'
+                - title: Glue API- Shopping Lists Feature Integration
+                  url: /docs/scos/dev/migration-and-integration/feature-integration-guides/glue-api/glue-api-shoppi.html
+                  include_versions:
+                    - '202005.0'
+                - title: Glue API- Order Management Feature Integration
+                  url: /docs/scos/dev/migration-and-integration/feature-integration-guides/glue-api/glue-api-order-.html
+                  include_versions:
+                    - '202005.0'
+                - title: Glue API- Shipment feature integration
+                  url: /docs/scos/dev/migration-and-integration/feature-integration-guides/glue-api/glue-api-shipme.html
+                  include_versions:
+                    - '202009.0'
+                    - '202108.0'
+                - title: Glue API- Availability Notification feature integration
+                  url: /docs/scos/dev/migration-and-integration/feature-integration-guides/glue-api/glue-api-availa.html
+                  include_versions:
+                    - '202108.0'
+                - title: Glue API- Payments feature integration
+                  url: /docs/scos/dev/migration-and-integration/feature-integration-guides/glue-api/glue-api-paymen.html
+                  include_versions:
+                    - '202009.0'
+                    - '202108.0'
+                - title: Glue API- Navigation feature integration
+                  url: /docs/scos/dev/migration-and-integration/feature-integration-guides/glue-api/glue-api-naviga.html
+                  include_versions:
+                    - '202009.0'
+                    - '202108.0'
+                - title: Glue API- Glue application feature integration
+                  url: /docs/scos/dev/migration-and-integration/feature-integration-guides/glue-api/glue-api-glue-a.html
+                  include_versions:
+                    - '202009.0'
+                    - '202108.0'
+                - title: Glue API- Checkout feature integration
+                  url: /docs/scos/dev/migration-and-integration/feature-integration-guides/glue-api/glue-api-checko.html
+                  include_versions:
+                    - '202009.0'
+                    - '202108.0'
+                - title: Glue API- Customer access feature integration
+                  url: /docs/scos/dev/migration-and-integration/feature-integration-guides/glue-api/glue-api-custom.html
+                  include_versions:
+                    - '202009.0'
+                    - '202108.0'
+                - title: Glue API- Measurement units feature integration
+                  url: /docs/scos/dev/migration-and-integration/feature-integration-guides/glue-api/glue-api-measur.html
+                  include_versions:
+                    - '202009.0'
+                    - '202108.0'
+                - title: Glue API- Product Configuration feature integration
+                  url: /docs/scos/dev/migration-and-integration/feature-integration-guides/glue-api/glue-api-produc.html
+                  include_versions:
+                    - '202108.0'
+                - title: Glue API- Configurable Bundle + Product feature integration
+                  url: /docs/scos/dev/migration-and-integration/feature-integration-guides/glue-api/glue-api-config.html
+                  include_versions:
+                    - '202108.0'
+                - title: Glue API- Alternative products feature integration
+                  url: /docs/scos/dev/migration-and-integration/feature-integration-guides/glue-api/glue-api-altern.html
+                  include_versions:
+                    - '202009.0'
+                    - '202108.0'
+                - title: Glue API- Inventory Management feature integration
+                  url: /docs/scos/dev/migration-and-integration/feature-integration-guides/glue-api/glue-api-invent.html
+                  include_versions:
+                    - '202009.0'
+                    - '202108.0'
+                - title: Glue API- Content items API feature integration
+                  url: /docs/scos/dev/migration-and-integration/feature-integration-guides/glue-api/glue-api-conten.html
+                  include_versions:
+                    - '202009.0'
+                    - '202108.0'
+                - title: Glue API- Shopping lists feature integration
+                  url: /docs/scos/dev/migration-and-integration/feature-integration-guides/glue-api/glue-api-shoppi.html
+                  include_versions:
+                    - '202009.0'
+                    - '202108.0'
+                - title: Glue API installation and configuration
+                  url: /docs/scos/dev/migration-and-integration/feature-integration-guides/glue-api/glue-api-instal.html
+                  include_versions:
+                    - '202009.0'
+                    - '202108.0'
+                - title: Glue API- Cart feature integration
+                  url: /docs/scos/dev/migration-and-integration/feature-integration-guides/glue-api/glue-api-cart-f.html
+                  include_versions:
+                    - '202009.0'
+                    - '202108.0'
+                - title: Glue API- Promotions & discounts feature integration
+                  url: /docs/scos/dev/migration-and-integration/feature-integration-guides/glue-api/glue-api-promot.html
+                  include_versions:
+                    - '202009.0'
+                    - '202108.0'
+                - title: Glue API- Company account feature integration
+                  url: /docs/scos/dev/migration-and-integration/feature-integration-guides/glue-api/glue-api-compan.html
+                  include_versions:
+                    - '202009.0'
+                    - '202108.0'
+                - title: Glue API- Development Tools feature integration
+                  url: /docs/scos/dev/migration-and-integration/feature-integration-guides/glue-api/glue-api-develo.html
+                  include_versions:
+                    - '202108.0'
+                - title: Glue API- Return management feature integration
+                  url: /docs/scos/dev/migration-and-integration/feature-integration-guides/glue-api/glue-api-return.html
+                  include_versions:
+                    - '202009.0'
+                    - '202108.0'
+                - title: Glue API- Spryker Сore feature integration
+                  url: /docs/scos/dev/migration-and-integration/feature-integration-guides/glue-api/glue-api-spryke.html
+                  include_versions:
+                    - '202108.0'
+                - title: Glue API- Product price feature integration
+                  url: /docs/scos/dev/migration-and-integration/feature-integration-guides/glue-api/glue-api-prices.html
+                  include_versions:
+                    - '202108.0'
+                - title: Glue API- Agent Assist feature integration
+                  url: /docs/scos/dev/migration-and-integration/feature-integration-guides/glue-api/glue-api-agent-.html
+                  include_versions:
+                    - '202009.0'
+                    - '202108.0'
+                - title: Glue API- Wishlist feature integration
+                  url: /docs/scos/dev/migration-and-integration/feature-integration-guides/glue-api/glue-api-wishli.html
+                  include_versions:
+                    - '202009.0'
+                    - '202108.0'
+                - title: Glue API- Category management feature integration
+                  url: /docs/scos/dev/migration-and-integration/feature-integration-guides/glue-api/glue-api-catego.html
+                  include_versions:
+                    - '202009.0'
+                    - '202108.0'
+                - title: Glue API- Order Management feature integration
+                  url: /docs/scos/dev/migration-and-integration/feature-integration-guides/glue-api/glue-api-order-.html
+                  include_versions:
+                    - '202108.0'
+                - title: Glue API- Catalog feature integration
+                  url: /docs/scos/dev/migration-and-integration/feature-integration-guides/glue-api/catalog-api-fea.html
+                  include_versions:
+                    - '202009.0'
+                    - '202108.0'
+                - title: Glue API- CMS feature integration guide
+                  url: /docs/scos/dev/migration-and-integration/feature-integration-guides/glue-api/glue-api-cms-fe.html
+                  include_versions:
+                    - '202108.0'
+                - title: Glue API- Product options feature integration
+                  url: /docs/scos/dev/migration-and-integration/feature-integration-guides/glue-api/glue-api-produc.html
+                  include_versions:
+                    - '202009.0'
+                - title: Glue API- Spryker core feature integration
+                  url: /docs/scos/dev/migration-and-integration/feature-integration-guides/glue-api/glue-api-spryke.html
+                  include_versions:
+                    - '202009.0'
+                - title: Glue API- Order management feature integration
+                  url: /docs/scos/dev/migration-and-integration/feature-integration-guides/glue-api/glue-api-order-.html
+                  include_versions:
+                    - '202009.0'
+                - title: Products Feature Integration
+                  url: /docs/scos/dev/migration-and-integration/feature-integration-guides/glue-api/products-featur.html
+                  include_versions:
+                    - '201907.0'
+                - title: Multiple Carts API Feature Integration
+                  url: /docs/scos/dev/migration-and-integration/feature-integration-guides/glue-api/multiple-carts-.html
+                  include_versions:
+                    - '201907.0'
+                - title: Glue- Cart Feature Integration
+                  url: /docs/scos/dev/migration-and-integration/feature-integration-guides/glue-api/cart-feature-in.html
+                  include_versions:
+                    - '201907.0'
+                - title: Store API Feature Integration
+                  url: /docs/scos/dev/migration-and-integration/feature-integration-guides/glue-api/store-api-featu.html
+                  include_versions:
+                    - '201903.0'
+                    - '201907.0'
+                - title: Inventory Management Feature Integration
+                  url: /docs/scos/dev/migration-and-integration/feature-integration-guides/glue-api/inventory-manag.html
+                  include_versions:
+                    - '201903.0'
+                    - '201907.0'
+                - title: Tax API Feature Integration
+                  url: /docs/scos/dev/migration-and-integration/feature-integration-guides/glue-api/tax-api-feature.html
+                  include_versions:
+                    - '201907.0'
+                - title: Checkout Feature Integration
+                  url: /docs/scos/dev/migration-and-integration/feature-integration-guides/glue-api/checkout-featur.html
+                  include_versions:
+                    - '201907.0'
+                - title: Product Category Relationship Feature Integration
+                  url: /docs/scos/dev/migration-and-integration/feature-integration-guides/glue-api/product-categor.html
+                  include_versions:
+                    - '201903.0'
+                    - '201907.0'
+                - title: GLUE- Promotions & Discounts Feature Integration
+                  url: /docs/scos/dev/migration-and-integration/feature-integration-guides/glue-api/promotions-and-.html
+                  include_versions:
+                    - '201907.0'
+                - title: Navigation API Feature Integration
+                  url: /docs/scos/dev/migration-and-integration/feature-integration-guides/glue-api/navigation-api-.html
+                  include_versions:
+                    - '201903.0'
+                    - '201907.0'
+                - title: Category Management Feature Integration
+                  url: /docs/scos/dev/migration-and-integration/feature-integration-guides/glue-api/glue-api-catego.html
+                  include_versions:
+                    - '201907.0'
+                - title: Shared Carts Feature Integration
+                  url: /docs/scos/dev/migration-and-integration/feature-integration-guides/glue-api/shared-carts-fe.html
+                  include_versions:
+                    - '201907.0'
+                - title: Customer Account Management Feature Integration
+                  url: /docs/scos/dev/migration-and-integration/feature-integration-guides/glue-api/customer-accoun.html
+                  include_versions:
+                    - '201907.0'
+                - title: Catalog Feature Integration
+                  url: /docs/scos/dev/migration-and-integration/feature-integration-guides/glue-api/catalog-api-fea.html
+                  include_versions:
+                    - '201907.0'
+                - title: Product Relations API Feature Integration
+                  url: /docs/scos/dev/migration-and-integration/feature-integration-guides/glue-api/product-relatio.html
+                  include_versions:
+                    - '201903.0'
+                    - '201907.0'
+                - title: Glue- Payments Feature Integration
+                  url: /docs/scos/dev/migration-and-integration/feature-integration-guides/glue-api/payments-api-fe.html
+                  include_versions:
+                    - '201907.0'
+                - title: Discontinued Products API Feature Integration
+                  url: /docs/scos/dev/migration-and-integration/feature-integration-guides/glue-api/discontinued-pr.html
+                  include_versions:
+                    - '201903.0'
+                    - '201907.0'
+                - title: Content Items API Feature Integration
+                  url: /docs/scos/dev/migration-and-integration/feature-integration-guides/glue-api/content-items-a.html
+                  include_versions:
+                    - '201907.0'
+                - title: Payments API Feature Integration
+                  url: /docs/scos/dev/migration-and-integration/feature-integration-guides/glue-api/payments-api-fe.html
+                  include_versions:
+                    - '201903.0'
+            - title: Navigation Module Integration
+              url: /docs/scos/dev/migration-and-integration/feature-integration-guides/navigation-modu.html
+              include_versions:
+                - '201903.0'
+            - title: Reclamations Feature Integration
+              url: /docs/scos/dev/migration-and-integration/feature-integration-guides/reclamations-fe.html
+              include_versions:
+                - '201903.0'
+                - '201907.0'
+                - '202001.0'
+                - '202005.0'
+            - title: Persistent Cart Sharing + Shared Carts Feature Integration
+              url: /docs/scos/dev/migration-and-integration/feature-integration-guides/persisitent-car.html
+              include_versions:
+                - '201907.0'
+                - '202001.0'
+                - '202005.0'
+            - title: About Integration Guides
+              url: /docs/scos/dev/migration-and-integration/feature-integration-guides/about-integrati.html
+              include_versions:
+                - '202001.0'
+                - '202005.0'
+            - title: Customer Access Feature Integration
+              url: /docs/scos/dev/migration-and-integration/feature-integration-guides/customer-access.html
+              include_versions:
+                - '201903.0'
+                - '201907.0'
+                - '202001.0'
+                - '202005.0'
+            - title: Quick Order- Non-splittable Products Feature Integration
+              url: /docs/scos/dev/migration-and-integration/feature-integration-guides/quick-order-non.html
+              include_versions:
+                - '201903.0'
+                - '201907.0'
+                - '202001.0'
+            - title: Payments Feature Integration
+              url: /docs/scos/dev/migration-and-integration/feature-integration-guides/payments-featur.html
+              include_versions:
+                - '202001.0'
+                - '202005.0'
+            - title: Installing the Category CMS Blocks
+              url: /docs/scos/dev/migration-and-integration/feature-integration-guides/enabling-catego.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+                - '201907.0'
+                - '202001.0'
+                - '202005.0'
+            - title: Product Group Feature Integration
+              url: /docs/scos/dev/migration-and-integration/feature-integration-guides/product-group-f.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+                - '201907.0'
+                - '202001.0'
+                - '202005.0'
+            - title: Alternative Products- Discontinued Products Feature Integration
+              url: /docs/scos/dev/migration-and-integration/feature-integration-guides/alternative-pro.html
+              include_versions:
+                - '202001.0'
+                - '202005.0'
+            - title: Gift Cards Feature Integration
+              url: /docs/scos/dev/migration-and-integration/feature-integration-guides/gift-cards-feat.html
+              include_versions:
+                - '201907.0'
+                - '202001.0'
+                - '202005.0'
+            - title: Resource Sharing Feature Integration
+              url: /docs/scos/dev/migration-and-integration/feature-integration-guides/resource-sharin.html
+              include_versions:
+                - '201907.0'
+                - '202001.0'
+                - '202005.0'
+            - title: Discount Promotion Feature Integration
+              url: /docs/scos/dev/migration-and-integration/feature-integration-guides/discount-promot.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+                - '201907.0'
+                - '202001.0'
+                - '202005.0'
+            - title: Quick Order- Packaging Units Feature Integration
+              url: /docs/scos/dev/migration-and-integration/feature-integration-guides/quick-order-pac.html
+              include_versions:
+                - '201903.0'
+                - '201907.0'
+                - '202001.0'
+            - title: Scheduled Prices Feature Integration
+              url: /docs/scos/dev/migration-and-integration/feature-integration-guides/scheduled-price.html
+              include_versions:
+                - '201907.0'
+                - '202001.0'
+                - '202005.0'
+            - title: Multi-store CMS Block Feature Integration
+              url: /docs/scos/dev/migration-and-integration/feature-integration-guides/multi-store-cms.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+                - '201907.0'
+                - '202001.0'
+                - '202005.0'
+            - title: CMS + Catalog Feature Integration
+              url: /docs/scos/dev/migration-and-integration/feature-integration-guides/cms-pages-in-se.html
+              include_versions:
+                - '202001.0'
+                - '202005.0'
+            - title: Merchants and Merchant Relations Feature Integration
+              url: /docs/scos/dev/migration-and-integration/feature-integration-guides/merchant-mercha.html
+              include_versions:
+                - '201903.0'
+            - title: Shared Carts Feature Integration
+              url: /docs/scos/dev/migration-and-integration/feature-integration-guides/shared-carts-fe.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+                - '201907.0'
+                - '202001.0'
+                - '202005.0'
+            - title: Shipment Feature Integration
+              url: /docs/scos/dev/migration-and-integration/feature-integration-guides/shipment-featur.html
+              include_versions:
+                - '202001.0'
+                - '202005.0'
+            - title: Back Office Feature Integration
+              url: /docs/scos/dev/migration-and-integration/feature-integration-guides/back-office-fea.html
+              include_versions:
+                - '201903.0'
+                - '201907.0'
+                - '202001.0'
+                - '202005.0'
+            - title: Quick Order Feature Integration
+              url: /docs/scos/dev/migration-and-integration/feature-integration-guides/quick-order-fea.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+                - '201907.0'
+                - '202001.0'
+                - '202005.0'
+            - title: Spryker Core Feature Integration
+              url: /docs/scos/dev/migration-and-integration/feature-integration-guides/spryker-core-fe.html
+              include_versions:
+                - '201907.0'
+                - '202001.0'
+                - '202005.0'
+            - title: Quick Order- Discontinued Products Feature Integration
+              url: /docs/scos/dev/migration-and-integration/feature-integration-guides/quick-order-dis.html
+              include_versions:
+                - '201903.0'
+                - '201907.0'
+                - '202001.0'
+            - title: Customer Account Management Feature Integration
+              url: /docs/scos/dev/migration-and-integration/feature-integration-guides/customer-accoun.html
+              include_versions:
+                - '201907.0'
+                - '202001.0'
+                - '202005.0'
+            - title: Product Set Feature Integration
+              url: /docs/scos/dev/migration-and-integration/feature-integration-guides/product-set-fea.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+                - '201907.0'
+                - '202001.0'
+                - '202005.0'
+            - title: Quotation Process + Multiple Carts Feature Integration
+              url: /docs/scos/dev/migration-and-integration/feature-integration-guides/quotation-proce.html
+              include_versions:
+                - '202001.0'
+                - '202005.0'
+            - title: Approval Process Feature Integration
+              url: /docs/scos/dev/migration-and-integration/feature-integration-guides/approval-proces.html
+              include_versions:
+                - '201903.0'
+                - '201907.0'
+                - '202001.0'
+                - '202005.0'
+            - title: Quick Order- Measurement Units Feature Integration
+              url: /docs/scos/dev/migration-and-integration/feature-integration-guides/quick-order-mea.html
+              include_versions:
+                - '201903.0'
+                - '201907.0'
+                - '202001.0'
+            - title: Product Lists Feature Integration
+              url: /docs/scos/dev/migration-and-integration/feature-integration-guides/product-lists-f.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+                - '201907.0'
+                - '202001.0'
+                - '202005.0'
+            - title: Product Reviews Feature Integration
+              url: /docs/scos/dev/migration-and-integration/feature-integration-guides/product-review-.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+                - '201907.0'
+                - '202001.0'
+                - '202005.0'
+            - title: Minimum Order Value Feature Integration
+              url: /docs/scos/dev/migration-and-integration/feature-integration-guides/minimum-order-v.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+                - '201907.0'
+                - '202001.0'
+                - '202005.0'
+            - title: Category Filters Feature Integration
+              url: /docs/scos/dev/migration-and-integration/feature-integration-guides/category-filter.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+                - '201907.0'
+                - '202001.0'
+                - '202005.0'
+            - title: Shipment + Approval Process Feature Integration
+              url: /docs/scos/dev/migration-and-integration/feature-integration-guides/shipment-approv.html
+              include_versions:
+                - '202001.0'
+                - '202005.0'
+            - title: Product Packaging Unit Feature Integration
+              url: /docs/scos/dev/migration-and-integration/feature-integration-guides/product-packagi.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+                - '201907.0'
+                - '202001.0'
+                - '202005.0'
+            - title: Multi-Store Products Feature Integration
+              url: /docs/scos/dev/migration-and-integration/feature-integration-guides/product-store-r.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+                - '201907.0'
+                - '202001.0'
+                - '202005.0'
+            - title: Comments Feature Integration
+              url: /docs/scos/dev/migration-and-integration/feature-integration-guides/comments-featur.html
+              include_versions:
+                - '201907.0'
+                - '202001.0'
+                - '202005.0'
+            - title: Product Lists + Catalog Feature Integration
+              url: /docs/scos/dev/migration-and-integration/feature-integration-guides/product-lists-c.html
+              include_versions:
+                - '202001.0'
+                - '202005.0'
+            - title: Volume Prices Feature Integration
+              url: /docs/scos/dev/migration-and-integration/feature-integration-guides/volume-prices-f.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+                - '201907.0'
+                - '202001.0'
+                - '202005.0'
+            - title: Payment Provider Integration
+              url: /docs/scos/dev/migration-and-integration/feature-integration-guides/payment-provide.html
+              include_versions:
+                - '201903.0'
+            - title: Configurable Bundle Feature Integration
+              url: /docs/scos/dev/migration-and-integration/feature-integration-guides/configurable-bu.html
+              include_versions:
+                - '202001.0'
+                - '202005.0'
+            - title: Comments + Persistent Cart Feature Integration
+              url: /docs/scos/dev/migration-and-integration/feature-integration-guides/comments-persis.html
+              include_versions:
+                - '201907.0'
+                - '202001.0'
+                - '202005.0'
+            - title: Shopping Lists + Product Options Feature Integration
+              url: /docs/scos/dev/migration-and-integration/feature-integration-guides/shopping-lists-.html
+              include_versions:
+                - '201811.0'
+                - '201907.0'
+                - '202005.0'
+            - title: Multiple Carts- Reorder Feature Integration
+              url: /docs/scos/dev/migration-and-integration/feature-integration-guides/multiple-carts-.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+            - title: Splittable Order Items Feature Integration
+              url: /docs/scos/dev/migration-and-integration/feature-integration-guides/splittable-orde.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+                - '201907.0'
+            - title: Product Measurement Units Feature Integration
+              url: /docs/scos/dev/migration-and-integration/feature-integration-guides/product-measure.html
+              include_versions:
+                - '201811.0'
+            - title: About Integration
+              url: /docs/scos/dev/migration-and-integration/feature-integration-guides/about-integrati.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+                - '201907.0'
+            - title: Product Relation Integration
+              url: /docs/scos/dev/migration-and-integration/feature-integration-guides/product-relatio.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+                - '201907.0'
+            - title: Business on Behalf Feature Integration
+              url: /docs/scos/dev/migration-and-integration/feature-integration-guides/business-on-beh.html
+              include_versions:
+                - '201811.0'
+            - title: Multiple Carts + Quick Order Feature Integration
+              url: /docs/scos/dev/migration-and-integration/feature-integration-guides/multiple-carts-.html
+              include_versions:
+                - '202005.0'
+            - title: Quick Order + Shopping Lists Feature Integration
+              url: /docs/scos/dev/migration-and-integration/feature-integration-guides/quick-order-sho.html
+              include_versions:
+                - '202005.0'
+            - title: Sales Data Export Feature Integration
+              url: /docs/scos/dev/migration-and-integration/feature-integration-guides/sales-data-expo.html
+              include_versions:
+                - '202005.0'
+            - title: Product Label 1.0 Feature Integrtion
+              url: /docs/scos/dev/migration-and-integration/feature-integration-guides/product-label-f.html
+              include_versions:
+                - '201903.0'
+                - '201907.0'
+                - '202005.0'
+            - title: Shipment + Cart Feature Integration
+              url: /docs/scos/dev/migration-and-integration/feature-integration-guides/shipment-cart-f.html
+              include_versions:
+                - '202005.0'
+            - title: Quick Order + Non-splittable Products Feature Integration
+              url: /docs/scos/dev/migration-and-integration/feature-integration-guides/quick-order-non.html
+              include_versions:
+                - '202005.0'
+            - title: Order Management Feature Integration
+              url: /docs/scos/dev/migration-and-integration/feature-integration-guides/order-managemen.html
+              include_versions:
+                - '202005.0'
+            - title: Quick Order + Packaging Units Feature Integration
+              url: /docs/scos/dev/migration-and-integration/feature-integration-guides/quick-order-pac.html
+              include_versions:
+                - '202005.0'
+            - title: Product Group + Cart Feature Integration
+              url: /docs/scos/dev/migration-and-integration/feature-integration-guides/product-group-c.html
+              include_versions:
+                - '202005.0'
+            - title: Quick Order + Discontinued Products Feature Integration
+              url: /docs/scos/dev/migration-and-integration/feature-integration-guides/quick-order-dis.html
+              include_versions:
+                - '202005.0'
+            - title: Product + Order Management Feature Integration
+              url: /docs/scos/dev/migration-and-integration/feature-integration-guides/product-order-m.html
+              include_versions:
+                - '202005.0'
+            - title: Quick Order + Measurement Units Feature Integration
+              url: /docs/scos/dev/migration-and-integration/feature-integration-guides/quick-order-mea.html
+              include_versions:
+                - '202005.0'
+            - title: Product Group + Product Labels Feature Integration
+              url: /docs/scos/dev/migration-and-integration/feature-integration-guides/product-group-p.html
+              include_versions:
+                - '202005.0'
+            - title: Product Relations Feature Integration
+              url: /docs/scos/dev/migration-and-integration/feature-integration-guides/product-relatio.html
+              include_versions:
+                - '202005.0'
+            - title: Shopping lists + product options feature integration
+              url: /docs/scos/dev/migration-and-integration/feature-integration-guides/shopping-lists-.html
+              include_versions:
+                - '202108.0'
+            - title: Prices per merchant relation feature integration
+              url: /docs/scos/dev/migration-and-integration/feature-integration-guides/prices-per-merc.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+            - title: Content Items feature integration
+              url: /docs/scos/dev/migration-and-integration/feature-integration-guides/content-items-f.html
+              include_versions:
+                - '202108.0'
+            - title: Multiple carts + quick order feature integration
+              url: /docs/scos/dev/migration-and-integration/feature-integration-guides/multiple-carts-.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+            - title: Prices feature integration
+              url: /docs/scos/dev/migration-and-integration/feature-integration-guides/prices-feature-.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+            - title: Company account + order management feature integration
+              url: /docs/scos/dev/migration-and-integration/feature-integration-guides/company-account.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+            - title: Comments + order management feature integration
+              url: /docs/scos/dev/migration-and-integration/feature-integration-guides/comments-order-.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+            - title: Queue data import feature integration
+              url: /docs/scos/dev/migration-and-integration/feature-integration-guides/queue-data-impo.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+            - title: Product feature integration
+              url: /docs/scos/dev/migration-and-integration/feature-integration-guides/product-feature.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+            - title: Cart integration
+              url: /docs/scos/dev/migration-and-integration/feature-integration-guides/cart-integratio.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+            - title: Cart feature integration
+              url: /docs/scos/dev/migration-and-integration/feature-integration-guides/cart-feature-in.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+            - title: Product + cart feature integration
+              url: /docs/scos/dev/migration-and-integration/feature-integration-guides/product-cart-fe.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+            - title: Inventory management feature integration
+              url: /docs/scos/dev/migration-and-integration/feature-integration-guides/inventory-manag.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+            - title: Catalog + Category Management feature integration
+              url: /docs/scos/dev/migration-and-integration/feature-integration-guides/catalog-categor.html
+              include_versions:
+                - '202108.0'
+            - title: Custom order reference feature integration
+              url: /docs/scos/dev/migration-and-integration/feature-integration-guides/custom-order-re.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+            - title: Product Sets feature integration
+              url: /docs/scos/dev/migration-and-integration/feature-integration-guides/product-sets-fe.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+            - title: Agent Assist + Cart feature integration
+              url: /docs/scos/dev/migration-and-integration/feature-integration-guides/agent-assist-ca.html
+              include_versions:
+                - '202108.0'
+            - title: Enabling the content widget
+              url: /docs/scos/dev/migration-and-integration/feature-integration-guides/enabling-cms-wi.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+            - title: Product Groups feature integration
+              url: /docs/scos/dev/migration-and-integration/feature-integration-guides/product-groups-.html
+              include_versions:
+                - '202108.0'
+            - title: Navigation feature integration
+              url: /docs/scos/dev/migration-and-integration/feature-integration-guides/navigation-feat.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+            - title: Search widget for concrete products feature integration
+              url: /docs/scos/dev/migration-and-integration/feature-integration-guides/search-widget-f.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+            - title: Cart + non-splittable products feature integration
+              url: /docs/scos/dev/migration-and-integration/feature-integration-guides/cart-non-splitt.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+            - title: Return management feature integration
+              url: /docs/scos/dev/migration-and-integration/feature-integration-guides/return-manageme.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+            - title: Permissions feature integration
+              url: /docs/scos/dev/migration-and-integration/feature-integration-guides/permissions-fea.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+            - title: Persistent cart sharing feature integration
+              url: /docs/scos/dev/migration-and-integration/feature-integration-guides/persistent-cart.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+            - title: Product labels + promotions & discounts feature integration
+              url: /docs/scos/dev/migration-and-integration/feature-integration-guides/product-labels-.html
+              include_versions:
+                - '202108.0'
+            - title: Product bundles + order management feature integration
+              url: /docs/scos/dev/migration-and-integration/feature-integration-guides/product-bundles.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+            - title: Checkout + quotation process feature integration
+              url: /docs/scos/dev/migration-and-integration/feature-integration-guides/checkout-quotat.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+            - title: CMS feature integration
+              url: /docs/scos/dev/migration-and-integration/feature-integration-guides/cms-feature-int.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+            - title: Merchant product restrictions feature integration
+              url: /docs/scos/dev/migration-and-integration/feature-integration-guides/merchant-produc.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+            - title: Product images + configurable bundle feature integration
+              url: /docs/scos/dev/migration-and-integration/feature-integration-guides/product-images-.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+            - title: Agent Assist feature integration
+              url: /docs/scos/dev/migration-and-integration/feature-integration-guides/agent-assist-fe.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+            - title: Checkout feature integration
+              url: /docs/scos/dev/migration-and-integration/feature-integration-guides/checkout-featur.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+            - title: Product options + order management feature integration
+              url: /docs/scos/dev/migration-and-integration/feature-integration-guides/product-options.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+            - title: Category image feature integration
+              url: /docs/scos/dev/migration-and-integration/feature-integration-guides/category-image-.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+            - title: Merchant feature integration
+              url: /docs/scos/dev/migration-and-integration/feature-integration-guides/merchant-featur.html
+              include_versions:
+                - '202108.0'
+            - title: Product measurement unit feature integration
+              url: /docs/scos/dev/migration-and-integration/feature-integration-guides/product-measure.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+            - title: Enabling gift cards
+              url: /docs/scos/dev/migration-and-integration/feature-integration-guides/enabling-gift-c.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+            - title: Sales data export feature integration
+              url: /docs/scos/dev/migration-and-integration/feature-integration-guides/sales-data-expo.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+            - title: Merchant custom prices feature integration
+              url: /docs/scos/dev/migration-and-integration/feature-integration-guides/merchant-custom.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+            - title: Product Rating & Reviews feature integration
+              url: /docs/scos/dev/migration-and-integration/feature-integration-guides/product-rating-.html
+              include_versions:
+                - '202108.0'
+            - title: CMS + product lists + catalog feature integration
+              url: /docs/scos/dev/migration-and-integration/feature-integration-guides/cms-page-search.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+            - title: Shipment + cart feature integration
+              url: /docs/scos/dev/migration-and-integration/feature-integration-guides/shipment-cart-f.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+            - title: Product Configuration feature integration
+              url: /docs/scos/dev/migration-and-integration/feature-integration-guides/product-configu.html
+              include_versions:
+                - '202108.0'
+            - title: Reclamations feature integration
+              url: /docs/scos/dev/migration-and-integration/feature-integration-guides/reclamations-fe.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+            - title: Persistent cart sharing + shared carts feature integration
+              url: /docs/scos/dev/migration-and-integration/feature-integration-guides/persisitent-car.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+            - title: About integration guides
+              url: /docs/scos/dev/migration-and-integration/feature-integration-guides/about-integrati.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+            - title: Customer access feature integration
+              url: /docs/scos/dev/migration-and-integration/feature-integration-guides/customer-access.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+            - title: Quick order + non-splittable products feature integration
+              url: /docs/scos/dev/migration-and-integration/feature-integration-guides/quick-order-non.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+            - title: Payments feature integration
+              url: /docs/scos/dev/migration-and-integration/feature-integration-guides/payments-featur.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+            - title: Order management feature integration
+              url: /docs/scos/dev/migration-and-integration/feature-integration-guides/order-managemen.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+            - title: Alternative products feature integration
+              url: /docs/scos/dev/migration-and-integration/feature-integration-guides/alternative-pro.html
+              include_versions:
+                - '202108.0'
+            - title: Promotions & Discounts feature integration
+              url: /docs/scos/dev/migration-and-integration/feature-integration-guides/promotions-disc.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+            - title: Spryker Core Back Office feature integration
+              url: /docs/scos/dev/migration-and-integration/feature-integration-guides/spryker-core-ba.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+            - title: Gift cards feature integration
+              url: /docs/scos/dev/migration-and-integration/feature-integration-guides/gift-cards-feat.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+            - title: Resource sharing feature integration
+              url: /docs/scos/dev/migration-and-integration/feature-integration-guides/resource-sharin.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+            - title: Product + Category feature integration
+              url: /docs/scos/dev/migration-and-integration/feature-integration-guides/product-categor.html
+              include_versions:
+                - '202108.0'
+            - title: Quick order + packaging units feature integration
+              url: /docs/scos/dev/migration-and-integration/feature-integration-guides/quick-order-pac.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+            - title: Category Management feature integration
+              url: /docs/scos/dev/migration-and-integration/feature-integration-guides/category-manage.html
+              include_versions:
+                - '202108.0'
+            - title: Scheduled prices feature integration
+              url: /docs/scos/dev/migration-and-integration/feature-integration-guides/scheduled-price.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+            - title: Multi-store CMS block feature integration
+              url: /docs/scos/dev/migration-and-integration/feature-integration-guides/multi-store-cms.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+            - title: Quick Add to Cart + Shopping Lists feature integration
+              url: /docs/scos/dev/migration-and-integration/feature-integration-guides/quick-add-to-ca.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+            - title: CMS + catalog feature integration
+              url: /docs/scos/dev/migration-and-integration/feature-integration-guides/cms-pages-in-se.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+            - title: Product group + cart feature integration
+              url: /docs/scos/dev/migration-and-integration/feature-integration-guides/product-group-c.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+            - title: Shared carts feature integration
+              url: /docs/scos/dev/migration-and-integration/feature-integration-guides/shared-carts-fe.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+            - title: Shipment feature integration
+              url: /docs/scos/dev/migration-and-integration/feature-integration-guides/shipment-featur.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+            - title: Quick Add to Cart feature integration
+              url: /docs/scos/dev/migration-and-integration/feature-integration-guides/quick-order-fea.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+            - title: Spryker Сore feature integration
+              url: /docs/scos/dev/migration-and-integration/feature-integration-guides/spryker-core-fe.html
+              include_versions:
+                - '202108.0'
+            - title: Customer Account Management + Agent Assist feature integration
+              url: /docs/scos/dev/migration-and-integration/feature-integration-guides/customer-accoun.html
+              include_versions:
+                - '202108.0'
+            - title: Product + order management feature integration
+              url: /docs/scos/dev/migration-and-integration/feature-integration-guides/product-order-m.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+            - title: Quotation process feature integration
+              url: /docs/scos/dev/migration-and-integration/feature-integration-guides/quotation-proce.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+            - title: CMS + Category Management feature integration
+              url: /docs/scos/dev/migration-and-integration/feature-integration-guides/cms-category-ma.html
+              include_versions:
+                - '202108.0'
+            - title: Approval process feature integration
+              url: /docs/scos/dev/migration-and-integration/feature-integration-guides/approval-proces.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+            - title: Quick order + measurement units feature integration
+              url: /docs/scos/dev/migration-and-integration/feature-integration-guides/quick-order-mea.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+            - title: Product group + product rating & reviews feature integration
+              url: /docs/scos/dev/migration-and-integration/feature-integration-guides/product-group-p.html
+              include_versions:
+                - '202108.0'
+            - title: Agent Assist + Shopping List feature integration
+              url: /docs/scos/dev/migration-and-integration/feature-integration-guides/agent-assist-sh.html
+              include_versions:
+                - '202108.0'
+            - title: Product Lists feature integration
+              url: /docs/scos/dev/migration-and-integration/feature-integration-guides/product-lists-f.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+            - title: Product relations feature integration
+              url: /docs/scos/dev/migration-and-integration/feature-integration-guides/product-relatio.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+            - title: Category filters feature integration
+              url: /docs/scos/dev/migration-and-integration/feature-integration-guides/category-filter.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+            - title: Shipment + approval process feature integration
+              url: /docs/scos/dev/migration-and-integration/feature-integration-guides/shipment-approv.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+            - title: Discontinued products + product labels feature integration
+              url: /docs/scos/dev/migration-and-integration/feature-integration-guides/discontinued-pr.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+            - title: Product packaging unit feature integration
+              url: /docs/scos/dev/migration-and-integration/feature-integration-guides/product-packagi.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+            - title: Multi-store products feature integration
+              url: /docs/scos/dev/migration-and-integration/feature-integration-guides/product-store-r.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+            - title: Comments feature integration
+              url: /docs/scos/dev/migration-and-integration/feature-integration-guides/comments-featur.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+            - title: Product lists + catalog feature integration
+              url: /docs/scos/dev/migration-and-integration/feature-integration-guides/product-lists-c.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+            - title: Merchant B2B Contracts feature integration
+              url: /docs/scos/dev/migration-and-integration/feature-integration-guides/merchant-b2b-co.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+            - title: Availability Notification feature integration
+              url: /docs/scos/dev/migration-and-integration/feature-integration-guides/availability-no.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+            - title: Configurable bundle + order management feature integration
+              url: /docs/scos/dev/migration-and-integration/feature-integration-guides/configurable-bu.html
+              include_versions:
+                - '202108.0'
+            - title: Comments + persistent cart feature integration
+              url: /docs/scos/dev/migration-and-integration/feature-integration-guides/comments-persis.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+            - title: Microsoft Azure Active Directory
+              url: /docs/scos/dev/migration-and-integration/feature-integration-guides/microsoft-azure.html
+              include_versions:
+                - '202108.0'
+            - title: Shopping lists feature integration
+              url: /docs/scos/dev/migration-and-integration/feature-integration-guides/shopping-lists-.html
+              include_versions:
+                - '202009.0'
+            - title: Content items feature integration
+              url: /docs/scos/dev/migration-and-integration/feature-integration-guides/content-items-f.html
+              include_versions:
+                - '202009.0'
+            - title: Installing the product CMS block
+              url: /docs/scos/dev/migration-and-integration/feature-integration-guides/product-block.html
+              include_versions:
+                - '202009.0'
+            - title: Product labels feature integration
+              url: /docs/scos/dev/migration-and-integration/feature-integration-guides/product-labels-.html
+              include_versions:
+                - '202009.0'
+            - title: Product group feature integration
+              url: /docs/scos/dev/migration-and-integration/feature-integration-guides/product-group-f.html
+              include_versions:
+                - '202009.0'
+            - title: Alternative products + discontinued products feature integration
+              url: /docs/scos/dev/migration-and-integration/feature-integration-guides/alternative-pro.html
+              include_versions:
+                - '202009.0'
+            - title: Spryker core feature integration
+              url: /docs/scos/dev/migration-and-integration/feature-integration-guides/spryker-core-fe.html
+              include_versions:
+                - '202009.0'
+            - title: Customer account management + order management feature
+                integration
+              url: /docs/scos/dev/migration-and-integration/feature-integration-guides/customer-accoun.html
+              include_versions:
+                - '202009.0'
+            - title: Product group + product labels feature integration
+              url: /docs/scos/dev/migration-and-integration/feature-integration-guides/product-group-p.html
+              include_versions:
+                - '202009.0'
+            - title: Product reviews feature integration
+              url: /docs/scos/dev/migration-and-integration/feature-integration-guides/product-review-.html
+              include_versions:
+                - '202009.0'
+            - title: Configurable bundle feature integration
+              url: /docs/scos/dev/migration-and-integration/feature-integration-guides/configurable-bu.html
+              include_versions:
+                - '202009.0'
+            - title: Product is Available Again Feature Integration
+              url: /docs/scos/dev/migration-and-integration/feature-integration-guides/product-is-avai.html
+              include_versions:
+                - '201903.0'
+                - '201907.0'
+            - title: CMS Page- Search + Product Lists + Catalog Feature Integration
+              url: /docs/scos/dev/migration-and-integration/feature-integration-guides/cms-page-search.html
+              include_versions:
+                - '201903.0'
+                - '201907.0'
+            - title: Alternative Products Feature Integration
+              url: /docs/scos/dev/migration-and-integration/feature-integration-guides/alternative-pro.html
+              include_versions:
+                - '201903.0'
+                - '201907.0'
+            - title: Spryker in Docker
+              nested:
+                - title: Spryker in Docker Feature Integration Guides
+                  url: /docs/scos/dev/migration-and-integration/feature-integration-guides/spryker-in-docker/spryker-in-dock.html
+                  include_versions:
+                    - '201907.0'
+                - title: Propel Clean Command Feature Integration
+                  url: /docs/scos/dev/migration-and-integration/feature-integration-guides/spryker-in-docker/propel-clean-co.html
+                  include_versions:
+                    - '201907.0'
+            - title: CMS Page- Search + Catalog Feature Integration
+              url: /docs/scos/dev/migration-and-integration/feature-integration-guides/cms-pages-in-se.html
+              include_versions:
+                - '201903.0'
+                - '201907.0'
+            - title: Quotation Process + Approval Process Feature Integration
+              url: /docs/scos/dev/migration-and-integration/feature-integration-guides/quotation-proce.html
+              include_versions:
+                - '201907.0'
+            - title: Product Lists- Catalog Feature Integration
+              url: /docs/scos/dev/migration-and-integration/feature-integration-guides/product-lists-c.html
+              include_versions:
+                - '201903.0'
+                - '201907.0'
+            - title: Shopping Lists- Product Options Feature Integration
+              url: /docs/scos/dev/migration-and-integration/feature-integration-guides/shopping-lists-.html
+              include_versions:
+                - '201903.0'
+        - title: Migration concepts
+          nested:
+            - title: Search migration concept
+              nested:
+                - title: Migration Guide - CategoryPageSearch
+                  url: /docs/scos/dev/migration-and-integration/migration-concepts/search-migration-concept/migration-guide.html
+                  include_versions:
+                    - '202001.0'
+                - title: Search Migration Concept
+                  url: /docs/scos/dev/migration-and-integration/migration-concepts/search-migration-concept/search-migratio.html
+                  include_versions:
+                    - '202001.0'
+                    - '202005.0'
+                - title: Search migration concept
+                  url: /docs/scos/dev/migration-and-integration/migration-concepts/search-migration-concept/search-migratio.html
+                  include_versions:
+                    - '202009.0'
+                    - '202108.0'
+            - title: Split Delivery Migration Concept
+              url: /docs/scos/dev/migration-and-integration/migration-concepts/split-delivery-.html
+              include_versions:
+                - '202001.0'
+                - '202005.0'
+            - title: Decimal Stock Migration Concept
+              url: /docs/scos/dev/migration-and-integration/migration-concepts/decimal-stock-c.html
+              include_versions:
+                - '202001.0'
+                - '202005.0'
+            - title: About Migration Concepts
+              url: /docs/scos/dev/migration-and-integration/migration-concepts/about-migration.html
+              include_versions:
+                - '201903.0'
+                - '201907.0'
+                - '202001.0'
+                - '202005.0'
+            - title: CRUD Scheduled Prices Migration Concept
+              url: /docs/scos/dev/migration-and-integration/migration-concepts/crud-scheduled-.html
+              include_versions:
+                - '202001.0'
+                - '202005.0'
+            - title: Silex replacement
+              nested:
+                - title: Application
+                  url: /docs/scos/dev/migration-and-integration/migration-concepts/silex-replacement/application.html
+                - title: Silex Migration Guides
+                  nested:
+                    - title: Migration Guide - Session
+                      url: /docs/scos/dev/migration-and-integration/migration-concepts/silex-replacement/silex-migration-guides/migration-guide.html
+                      include_versions:
+                        - '202001.0'
+                - title: Container
+                  url: /docs/scos/dev/migration-and-integration/migration-concepts/silex-replacement/container-20190.html
+                - title: Silex Replacement
+                  url: /docs/scos/dev/migration-and-integration/migration-concepts/silex-replacement/silex-replaceme.html
+                  include_versions:
+                    - '201903.0'
+                    - '201907.0'
+                    - '202001.0'
+                    - '202005.0'
+                - title: Router
+                  nested:
+                    - title: Router
+                      url: /docs/scos/dev/migration-and-integration/migration-concepts/silex-replacement/router/router.html
+                      include_versions:
+                        - '201907.0'
+                        - '202001.0'
+                        - '202005.0'
+                    - title: Router Yves
+                      url: /docs/scos/dev/migration-and-integration/migration-concepts/silex-replacement/router/router-yves.html
+                      include_versions:
+                        - '201907.0'
+                        - '202001.0'
+                        - '202005.0'
+                        - '202009.0'
+                        - '202108.0'
+                    - title: Router Zed
+                      url: /docs/scos/dev/migration-and-integration/migration-concepts/silex-replacement/router/router-zed.html
+                      include_versions:
+                        - '201907.0'
+                        - '202001.0'
+                        - '202005.0'
+                        - '202009.0'
+                        - '202108.0'
+                - title: Silex replacement
+                  url: /docs/scos/dev/migration-and-integration/migration-concepts/silex-replacement/silex-replaceme.html
+                  include_versions:
+                    - '202009.0'
+                    - '202108.0'
+                - title: Migrating Away From Silex
+                  url: /docs/scos/dev/migration-and-integration/migration-concepts/silex-replacement/migrating-away-.html
+                  include_versions:
+                    - '201903.0'
+                    - '201907.0'
+            - title: Split delivery migration concept
+              url: /docs/scos/dev/migration-and-integration/migration-concepts/split-delivery-.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+            - title: Migrating from Twig v1 to Twig v3
+              url: /docs/scos/dev/migration-and-integration/migration-concepts/migrating-from-.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+            - title: Decimal Stock migration concept
+              url: /docs/scos/dev/migration-and-integration/migration-concepts/decimal-stock-c.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+            - title: About migration concepts
+              url: /docs/scos/dev/migration-and-integration/migration-concepts/about-migration.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+            - title: CRUD Scheduled Prices migration concept
+              url: /docs/scos/dev/migration-and-integration/migration-concepts/crud-scheduled-.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+        - title: Technical enhancements
+          nested:
+            - title: Custom Location for Static Assets
+              url: /docs/scos/dev/migration-and-integration/technical-enhancements/custom-location.html
+              include_versions:
+                - '202001.0'
+                - '202005.0'
+                - '202009.0'
+                - '202108.0'
+            - title: Search Initialization Improvement
+              url: /docs/scos/dev/migration-and-integration/technical-enhancements/search-initiali.html
+              include_versions:
+                - '202001.0'
+                - '202005.0'
+                - '202009.0'
+                - '202108.0'
+            - title: Health Checks
+              url: /docs/scos/dev/migration-and-integration/technical-enhancements/health-checks.html
+              include_versions:
+                - '202001.0'
+                - '202005.0'
+                - '202009.0'
+                - '202108.0'
+            - title: Dynamic Propel Configuration
+              url: /docs/scos/dev/migration-and-integration/technical-enhancements/dynamic-propel-.html
+              include_versions:
+                - '202001.0'
+                - '202005.0'
+                - '202009.0'
+                - '202108.0'
+            - title: Environment Configuration Enhancement
+              url: /docs/scos/dev/migration-and-integration/technical-enhancements/environment-con.html
+              include_versions:
+                - '202001.0'
+                - '202005.0'
+                - '202009.0'
+                - '202108.0'
+            - title: Propel Clean Command
+              url: /docs/scos/dev/migration-and-integration/technical-enhancements/propel-clean-co.html
+              include_versions:
+                - '202001.0'
+                - '202005.0'
+                - '202009.0'
+                - '202108.0'
+            - title: Cache of Unresolved Entities for Zed
+              url: /docs/scos/dev/migration-and-integration/technical-enhancements/cache-of-unreso.html
+              include_versions:
+                - '202005.0'
+                - '202009.0'
+                - '202108.0'
+            - title: Multiple publish queue structure
+              url: /docs/scos/dev/migration-and-integration/technical-enhancements/multiple-publis.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+            - title: Chromium browser for tests
+              url: /docs/scos/dev/migration-and-integration/technical-enhancements/chromium-browse.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+            - title: Enabling CMS block widget
+              url: /docs/scos/dev/migration-and-integration/technical-enhancements/enabling-cms-bl.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+            - title: MariaDB database engine
+              url: /docs/scos/dev/migration-and-integration/technical-enhancements/mariadb-databas.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+            - title: Frontend CSS Lazy Load integration
+              url: /docs/scos/dev/migration-and-integration/technical-enhancements/frontend-css-la.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+            - title: Basic SEO techniques integration guide
+              url: /docs/scos/dev/migration-and-integration/technical-enhancements/basic-seo-techn.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+            - title: Enabling the product CMS block
+              url: /docs/scos/dev/migration-and-integration/technical-enhancements/enabling-the-pr.html
+              include_versions:
+                - '202108.0'
+            - title: Separating different endpoint bootstraps
+              url: /docs/scos/dev/migration-and-integration/technical-enhancements/separating-diff.html
+              include_versions:
+                - '202108.0'
+            - title: Queue worker signal handling
+              url: /docs/scos/dev/migration-and-integration/technical-enhancements/queue-worker-si.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+            - title: Configuring dynamic Yves-Zed tokens
+              url: /docs/scos/dev/migration-and-integration/technical-enhancements/configuring-dyn.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+            - title: Symfony 5 integration
+              url: /docs/scos/dev/migration-and-integration/technical-enhancements/symfony-5-integ.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+            - title: Enabling the category CMS blocks
+              url: /docs/scos/dev/migration-and-integration/technical-enhancements/enabling-the-ca.html
+              include_versions:
+                - '202108.0'
+            - title: Installing the category CMS blocks
+              url: /docs/scos/dev/migration-and-integration/technical-enhancements/enabling-catego.html
+              include_versions:
+                - '202009.0'
+        - title: Float Stock for Products
+          nested:
+            - title: Float Stock for Products
+              url: /docs/scos/dev/migration-and-integration/float-stock-for-products/float-stock-for.html
+              include_versions:
+                - '201903.0'
+        - title: Module migration guides
+          nested:
+            - title: Migration Guide - CMS
+              url: /docs/scos/dev/migration-and-integration/module-migration-guides/mg-cms.html
+              include_versions:
+                - '201903.0'
+            - title: Migration Guide - Session
+              url: /docs/scos/dev/migration-and-integration/module-migration-guides/mg-session.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+                - '201907.0'
+                - '202001.0'
+            - title: Migration Guide - Currency
+              url: /docs/scos/dev/migration-and-integration/module-migration-guides/mg-currency.html
+              include_versions:
+                - '201903.0'
+            - title: Migration Guide - CMS Block Collector
+              url: /docs/scos/dev/migration-and-integration/module-migration-guides/mg-cms-block-co.html
+              include_versions:
+                - '201903.0'
+            - title: Migration Guide - MultiCartPage
+              url: /docs/scos/dev/migration-and-integration/module-migration-guides/mg-multi-cart-p.html
+              include_versions:
+                - '201903.0'
+            - title: Migration Guide - ManualOrderEntryGui
+              url: /docs/scos/dev/migration-and-integration/module-migration-guides/mg-manual-order.html
+              include_versions:
+                - '202001.0'
+                - '202005.0'
+                - '202009.0'
+                - '202108.0'
+            - title: Migration guide - Payone Suite
+              url: /docs/scos/dev/migration-and-integration/module-migration-guides/mg-payonesuite.html
+              include_versions:
+                - '201903.0'
+            - title: Migration Guide - OMS
+              url: /docs/scos/dev/migration-and-integration/module-migration-guides/mg-oms.html
+              include_versions:
+                - '201903.0'
+            - title: Migration Guide - ProductQuantityDataImport
+              url: /docs/scos/dev/migration-and-integration/module-migration-guides/mg-product-quan.html
+              include_versions:
+                - '202001.0'
+            - title: Migration Guide - CmsStorage
+              url: /docs/scos/dev/migration-and-integration/module-migration-guides/mg-cmsstorage.html
+            - title: Migration Guide - Customer
+              url: /docs/scos/dev/migration-and-integration/module-migration-guides/mg-customer.html
+              include_versions:
+                - '201903.0'
+            - title: Migration Guide - API Module
+              url: /docs/scos/dev/migration-and-integration/module-migration-guides/mg-api-module.html
+            - title: Migration Guide - ProductDetailPage
+              url: /docs/scos/dev/migration-and-integration/module-migration-guides/mg-product-deta.html
+              include_versions:
+                - '201903.0'
+            - title: Migration Guide - Shipment
+              url: /docs/scos/dev/migration-and-integration/module-migration-guides/mg-shipment.html
+              include_versions:
+                - '201903.0'
+            - title: Migration Guide - ShipmentGui
+              url: /docs/scos/dev/migration-and-integration/module-migration-guides/mg-shipment-gui.html
+              include_versions:
+                - '202001.0'
+                - '202005.0'
+                - '202009.0'
+                - '202108.0'
+            - title: Migration Guide - Category
+              url: /docs/scos/dev/migration-and-integration/module-migration-guides/mg-category.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+                - '201907.0'
+                - '202001.0'
+                - '202005.0'
+            - title: Migration Guide - OauthCompanyUser
+              url: /docs/scos/dev/migration-and-integration/module-migration-guides/mg-oauthcompany.html
+              include_versions:
+                - '201907.0'
+                - '202001.0'
+                - '202005.0'
+                - '202009.0'
+                - '202108.0'
+            - title: Migration Guide - CartPage
+              url: /docs/scos/dev/migration-and-integration/module-migration-guides/mg-cart-page.html
+              include_versions:
+                - '201903.0'
+            - title: Migration Guide - QuickOrder
+              url: /docs/scos/dev/migration-and-integration/module-migration-guides/mg-quick-order.html
+              include_versions:
+                - '201903.0'
+            - title: Migration Guide - Offer
+              url: /docs/scos/dev/migration-and-integration/module-migration-guides/mg-offer.html
+              include_versions:
+                - '201903.0'
+            - title: Migration Guide - ProductOption
+              url: /docs/scos/dev/migration-and-integration/module-migration-guides/mg-product-opti.html
+              include_versions:
+                - '202001.0'
+                - '202009.0'
+            - title: Migration Guide - ProductSetGui
+              url: /docs/scos/dev/migration-and-integration/module-migration-guides/mg-product-set-.html
+              include_versions:
+                - '202001.0'
+                - '202005.0'
+                - '202009.0'
+                - '202108.0'
+            - title: Migration Guide - CMSBlockStorage
+              url: /docs/scos/dev/migration-and-integration/module-migration-guides/migration-guide.html
+              include_versions:
+                - '202001.0'
+            - title: Migration Guide - ContentStorage
+              url: /docs/scos/dev/migration-and-integration/module-migration-guides/mg-contentstora.html
+              include_versions:
+                - '201907.0'
+                - '202001.0'
+                - '202005.0'
+                - '202009.0'
+                - '202108.0'
+            - title: Migration Guide - Monitoring
+              url: /docs/scos/dev/migration-and-integration/module-migration-guides/mg-monitoring.html
+              include_versions:
+                - '201903.0'
+            - title: Migration Guide - PriceProductSchedule
+              url: /docs/scos/dev/migration-and-integration/module-migration-guides/mg-price-produc.html
+              include_versions:
+                - '202001.0'
+            - title: Migration Guide - DiscountCalculatorConnector
+              url: /docs/scos/dev/migration-and-integration/module-migration-guides/mg-discount-cal.html
+              include_versions:
+                - '201903.0'
+            - title: Migration Guide - PriceCartConnector
+              url: /docs/scos/dev/migration-and-integration/module-migration-guides/mg-price-cart-c.html
+              include_versions:
+                - '202001.0'
+                - '202005.0'
+                - '202009.0'
+                - '202108.0'
+            - title: Migration Guide - SalesAggregator
+              url: /docs/scos/dev/migration-and-integration/module-migration-guides/mg-sales-aggreg.html
+              include_versions:
+                - '201903.0'
+            - title: Migration Guide - Tax
+              url: /docs/scos/dev/migration-and-integration/module-migration-guides/mg-tax.html
+              include_versions:
+                - '201903.0'
+            - title: Migration Guide - Multi-Currency
+              url: /docs/scos/dev/migration-and-integration/module-migration-guides/mg-multi-curren.html
+              include_versions:
+                - '201903.0'
+            - title: Migration Guide - Collector
+              url: /docs/scos/dev/migration-and-integration/module-migration-guides/mg-collector.html
+              include_versions:
+                - '201903.0'
+            - title: Migration Guide - StockSalesConnector
+              url: /docs/scos/dev/migration-and-integration/module-migration-guides/mg-stock-sales-.html
+              include_versions:
+                - '201903.0'
+            - title: Migration Guide - AvailabilityStorage
+              url: /docs/scos/dev/migration-and-integration/module-migration-guides/mg-availability.html
+              include_versions:
+                - '202001.0'
+                - '202005.0'
+            - title: Migration Guide - ShipmentCartConnector
+              url: /docs/scos/dev/migration-and-integration/module-migration-guides/mg-shipment-car.html
+              include_versions:
+                - '202001.0'
+                - '202005.0'
+                - '202009.0'
+                - '202108.0'
+            - title: Migration Guide - ProductPackagingUnitDataImport
+              url: /docs/scos/dev/migration-and-integration/module-migration-guides/mg-product-pack.html
+              include_versions:
+                - '202001.0'
+                - '202005.0'
+            - title: Migration Guide - Transfer
+              url: /docs/scos/dev/migration-and-integration/module-migration-guides/mg-transfer.html
+              include_versions:
+                - '201903.0'
+            - title: Migration Guide - Sales
+              url: /docs/scos/dev/migration-and-integration/module-migration-guides/mg-sales.html
+              include_versions:
+                - '201903.0'
+            - title: Migration Guide - ProductValidity
+              url: /docs/scos/dev/migration-and-integration/module-migration-guides/mg-product-vali.html
+              include_versions:
+                - '202001.0'
+                - '202005.0'
+                - '202009.0'
+                - '202108.0'
+            - title: Migration Guide - CMS Block Category Connector
+              url: /docs/scos/dev/migration-and-integration/module-migration-guides/mg-cms-block-ca.html
+              include_versions:
+                - '202001.0'
+                - '202005.0'
+            - title: Migration Guide - ShoppingListWidget
+              url: /docs/scos/dev/migration-and-integration/module-migration-guides/mg-shopping-lis.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+                - '201907.0'
+                - '202001.0'
+            - title: Migration Guide - CmsBlock
+              url: /docs/scos/dev/migration-and-integration/module-migration-guides/mg-cms-block.html
+              include_versions:
+                - '202001.0'
+                - '202005.0'
+                - '202009.0'
+                - '202108.0'
+            - title: Migration Guide - Quote
+              url: /docs/scos/dev/migration-and-integration/module-migration-guides/mg-quote.html
+              include_versions:
+                - '201903.0'
+            - title: Migration Guide - ProductListSearch
+              url: /docs/scos/dev/migration-and-integration/module-migration-guides/mg-product-list.html
+              include_versions:
+                - '201903.0'
+            - title: Migration Guide - Discount
+              url: /docs/scos/dev/migration-and-integration/module-migration-guides/mg-discount.html
+              include_versions:
+                - '201903.0'
+            - title: Migration Guide - ProductLabel
+              url: /docs/scos/dev/migration-and-integration/module-migration-guides/mg-product-labe.html
+              include_versions:
+                - '202001.0'
+                - '202009.0'
+            - title: Migration Guide - Catalog
+              url: /docs/scos/dev/migration-and-integration/module-migration-guides/mg-catalog.html
+              include_versions:
+                - '201903.0'
+            - title: Migration Guide - Stock
+              url: /docs/scos/dev/migration-and-integration/module-migration-guides/mg-stock.html
+              include_versions:
+                - '201903.0'
+            - title: Migration Guide - CustomerReorderWidget
+              url: /docs/scos/dev/migration-and-integration/module-migration-guides/mg-customer-reo.html
+              include_versions:
+                - '201903.0'
+            - title: Migration Guide - ProductRelationCollector
+              url: /docs/scos/dev/migration-and-integration/module-migration-guides/mg-product-rela.html
+              include_versions:
+                - '202001.0'
+                - '202005.0'
+                - '202009.0'
+                - '202108.0'
+            - title: Migration Guide - PriceProduct
+              url: /docs/scos/dev/migration-and-integration/module-migration-guides/mg-priceproduct.html
+              include_versions:
+                - '201903.0'
+            - title: Migration Guide - OfferGui
+              url: /docs/scos/dev/migration-and-integration/module-migration-guides/mg-offer-gui.html
+              include_versions:
+                - '201903.0'
+            - title: Migration Guide - CustomerPage
+              url: /docs/scos/dev/migration-and-integration/module-migration-guides/mg-customerpage.html
+              include_versions:
+                - '202001.0'
+                - '202005.0'
+                - '202009.0'
+                - '202108.0'
+            - title: Migration Guide - ProductBundle
+              url: /docs/scos/dev/migration-and-integration/module-migration-guides/mg-product-bund.html
+              include_versions:
+                - '202001.0'
+                - '202005.0'
+                - '202009.0'
+                - '202108.0'
+            - title: Migration Guide - Console
+              url: /docs/scos/dev/migration-and-integration/module-migration-guides/mg-console.html
+              include_versions:
+                - '201903.0'
+            - title: Migration Guide - Checkout
+              url: /docs/scos/dev/migration-and-integration/module-migration-guides/mg-checkout.html
+              include_versions:
+                - '201903.0'
+            - title: Migration Guide - RabbitMQ
+              url: /docs/scos/dev/migration-and-integration/module-migration-guides/mg-rabbitmq.html
+              include_versions:
+                - '201903.0'
+            - title: Migration Guide - SalesQuantity
+              url: /docs/scos/dev/migration-and-integration/module-migration-guides/mg-sales-quanti.html
+              include_versions:
+                - '201903.0'
+            - title: Migration Guide - QuoteRequestWidget
+              url: /docs/scos/dev/migration-and-integration/module-migration-guides/mg-quoterequest.html
+              include_versions:
+                - '202001.0'
+            - title: Migration Guide - Setup
+              url: /docs/scos/dev/migration-and-integration/module-migration-guides/mg-setup.html
+              include_versions:
+                - '201903.0'
+            - title: Migration guide - Payone Demoshop
+              url: /docs/scos/dev/migration-and-integration/module-migration-guides/mg-payonedemosh.html
+              include_versions:
+                - '201903.0'
+            - title: Migration Guide - Cart
+              url: /docs/scos/dev/migration-and-integration/module-migration-guides/mg-cart.html
+              include_versions:
+                - '201903.0'
+            - title: Glue API
+              nested:
+                - title: About Glue API Migration Guides
+                  url: /docs/scos/dev/migration-and-integration/module-migration-guides/glue-api/about-glue-api-.html
+                  include_versions:
+                    - '201811.0'
+                    - '201903.0'
+                    - '201907.0'
+                    - '202001.0'
+                    - '202005.0'
+                - title: Migration Guide - NavigationsRestApi
+                  url: /docs/scos/dev/migration-and-integration/module-migration-guides/glue-api/migration-guide.html
+                - title: CartsRestApi Migration Guide
+                  url: /docs/scos/dev/migration-and-integration/module-migration-guides/glue-api/cartsrestapi-mi.html
+                  include_versions:
+                    - '201903.0'
+                - title: Migration guide - ProductTaxSetsRestApi
+                  url: /docs/scos/dev/migration-and-integration/module-migration-guides/glue-api/producttaxsetsr.html
+                  include_versions:
+                    - '201903.0'
+                - title: Migration Guide - ProductAvailabilitiesRestApi
+                  url: /docs/scos/dev/migration-and-integration/module-migration-guides/glue-api/productavailabi.html
+                  include_versions:
+                    - '201903.0'
+                - title: CompanyUsersRestApi Migration Guide
+                  url: /docs/scos/dev/migration-and-integration/module-migration-guides/glue-api/companyusersres.html
+                  include_versions:
+                    - '201907.0'
+                    - '202001.0'
+                    - '202005.0'
+                    - '202009.0'
+                    - '202108.0'
+                - title: Migration Guide - CheckoutRestApi
+                  url: /docs/scos/dev/migration-and-integration/module-migration-guides/glue-api/mg-checkoutrest.html
+                  include_versions:
+                    - '202001.0'
+                    - '202005.0'
+                    - '202009.0'
+                    - '202108.0'
+                - title: CompanyUserAuthRestApi Migration Guide
+                  url: /docs/scos/dev/migration-and-integration/module-migration-guides/glue-api/companyuserauth.html
+                  include_versions:
+                    - '201907.0'
+                    - '202001.0'
+                    - '202005.0'
+                    - '202009.0'
+                    - '202108.0'
+                - title: Migration Guide - ContentBannersRestApi
+                  url: /docs/scos/dev/migration-and-integration/module-migration-guides/glue-api/mg-contentbanne.html
+                  include_versions:
+                    - '201907.0'
+                    - '202001.0'
+                    - '202005.0'
+                    - '202009.0'
+                    - '202108.0'
+                - title: CatalogSearchRestApi Migration Guide
+                  url: /docs/scos/dev/migration-and-integration/module-migration-guides/glue-api/catalogsearchre.html
+                  include_versions:
+                    - '201903.0'
+                - title: Migration Guide - OrdersRestApi
+                  url: /docs/scos/dev/migration-and-integration/module-migration-guides/glue-api/mg-ordersrestap.html
+                  include_versions:
+                    - '202001.0'
+                    - '202005.0'
+                    - '202009.0'
+                    - '202108.0'
+                - title: About Glue API migration guides
+                  url: /docs/scos/dev/migration-and-integration/module-migration-guides/glue-api/about-glue-api-.html
+                  include_versions:
+                    - '202009.0'
+                    - '202108.0'
+            - title: Migration Guide - Step Engine
+              url: /docs/scos/dev/migration-and-integration/module-migration-guides/mg-step-engine.html
+              include_versions:
+                - '201903.0'
+            - title: Migration Guide - SharedCartPage
+              url: /docs/scos/dev/migration-and-integration/module-migration-guides/mg-shared-cart-.html
+            - title: Migration Guide - SalesSplit
+              url: /docs/scos/dev/migration-and-integration/module-migration-guides/mg-sales-split.html
+              include_versions:
+                - '201903.0'
+            - title: Migration Guide - Payment
+              url: /docs/scos/dev/migration-and-integration/module-migration-guides/mg-payment.html
+              include_versions:
+                - '201903.0'
+            - title: Migration Guide - DiscountSalesAggregatorConnector
+              url: /docs/scos/dev/migration-and-integration/module-migration-guides/mg-discount-sal.html
+              include_versions:
+                - '201903.0'
+            - title: Migration Guide - Refund
+              url: /docs/scos/dev/migration-and-integration/module-migration-guides/mg-refund.html
+              include_versions:
+                - '201903.0'
+            - title: Migration Guide - Environment Configuration
+              url: /docs/scos/dev/migration-and-integration/module-migration-guides/mg-environment-.html
+              include_versions:
+                - '201903.0'
+            - title: Migration Guide - Publish and Synchronization
+              url: /docs/scos/dev/migration-and-integration/module-migration-guides/mg-pub-and-sync.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+                - '201907.0'
+                - '202001.0'
+                - '202005.0'
+            - title: Migration Guide - NavigationGui
+              url: /docs/scos/dev/migration-and-integration/module-migration-guides/mg-navigation-g.html
+              include_versions:
+                - '201903.0'
+            - title: Migration Guide - CmsPageSearch
+              url: /docs/scos/dev/migration-and-integration/module-migration-guides/mg-cmspagesearc.html
+            - title: Migration Guide - Business On Behalf Data Import
+              url: /docs/scos/dev/migration-and-integration/module-migration-guides/mg-business-on-.html
+              include_versions:
+                - '201903.0'
+            - title: Migration Guide - Wishlist
+              url: /docs/scos/dev/migration-and-integration/module-migration-guides/mg-wishlist.html
+              include_versions:
+                - '201903.0'
+            - title: Migration Guide - Touch
+              url: /docs/scos/dev/migration-and-integration/module-migration-guides/mg-touch.html
+              include_versions:
+                - '201903.0'
+            - title: About Migration Guides
+              url: /docs/scos/dev/migration-and-integration/module-migration-guides/about-migration.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+                - '201907.0'
+                - '202001.0'
+                - '202005.0'
+            - title: Migration Guide - Navigation
+              url: /docs/scos/dev/migration-and-integration/module-migration-guides/mg-navigation.html
+              include_versions:
+                - '201903.0'
+            - title: Migration Guide - ProductSearch
+              url: /docs/scos/dev/migration-and-integration/module-migration-guides/mg-product-sear.html
+              include_versions:
+                - '202001.0'
+                - '202005.0'
+                - '202108.0'
+            - title: Migration Guide - Calculation
+              url: /docs/scos/dev/migration-and-integration/module-migration-guides/mg-calculation.html
+              include_versions:
+                - '201903.0'
+            - title: Migration Guide - DiscountPromotionWidget
+              url: /docs/scos/dev/migration-and-integration/module-migration-guides/mg-discount-pro.html
+              include_versions:
+                - '201903.0'
+            - title: Migration Guide - Search
+              url: /docs/scos/dev/migration-and-integration/module-migration-guides/mg-search.html
+              include_versions:
+                - '201903.0'
+            - title: Migration Guide - ProductDiscountConnector
+              url: /docs/scos/dev/migration-and-integration/module-migration-guides/mg-product-disc.html
+              include_versions:
+                - '201903.0'
+            - title: Migration Guide - Content
+              url: /docs/scos/dev/migration-and-integration/module-migration-guides/mg-content-2019.html
+              include_versions:
+                - '201907.0'
+                - '202001.0'
+                - '202005.0'
+                - '202009.0'
+                - '202108.0'
+            - title: Migration Guide - ProductManagement
+              url: /docs/scos/dev/migration-and-integration/module-migration-guides/mg-product-mana.html
+              include_versions:
+                - '201903.0'
+            - title: Migration Guide - Merchant
+              url: /docs/scos/dev/migration-and-integration/module-migration-guides/mg-merchant.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+                - '201907.0'
+                - '202001.0'
+                - '202005.0'
+            - title: Migration Guide - ContentBannerGui
+              url: /docs/scos/dev/migration-and-integration/module-migration-guides/mg-contentbanne.html
+              include_versions:
+                - '201907.0'
+                - '202001.0'
+                - '202009.0'
+                - '202108.0'
+            - title: Migration Guide - Product
+              url: /docs/scos/dev/migration-and-integration/module-migration-guides/mg-product.html
+              include_versions:
+                - '201903.0'
+            - title: Migration Guide - ShipmentDiscountConnector
+              url: /docs/scos/dev/migration-and-integration/module-migration-guides/mg-shipment-dis.html
+              include_versions:
+                - '201903.0'
+            - title: Migration Guide - CartVariant
+              url: /docs/scos/dev/migration-and-integration/module-migration-guides/mg-cart-variant.html
+              include_versions:
+                - '202001.0'
+                - '202005.0'
+                - '202009.0'
+                - '202108.0'
+            - title: Migration Guide - ProductMeasurementUnitWidget
+              url: /docs/scos/dev/migration-and-integration/module-migration-guides/mg-product-meas.html
+              include_versions:
+                - '201907.0'
+                - '202001.0'
+                - '202009.0'
+            - title: Migration Guide - Price
+              url: /docs/scos/dev/migration-and-integration/module-migration-guides/mg-price.html
+              include_versions:
+                - '201903.0'
+            - title: Migration Guide - QuickOrderPage
+              url: /docs/scos/dev/migration-and-integration/module-migration-guides/mg-quick-order-.html
+            - title: Migration Guide - ShipmentCheckoutConnector
+              url: /docs/scos/dev/migration-and-integration/module-migration-guides/mg-shipment-che.html
+              include_versions:
+                - '202001.0'
+                - '202005.0'
+                - '202009.0'
+                - '202108.0'
+            - title: Migration Guide - CmsCollector
+              url: /docs/scos/dev/migration-and-integration/module-migration-guides/mg-cms-collecto.html
+              include_versions:
+                - '202001.0'
+                - '202005.0'
+                - '202009.0'
+                - '202108.0'
+            - title: Migration Guide - CompanyUser
+              url: /docs/scos/dev/migration-and-integration/module-migration-guides/mg-companyuser.html
+              include_versions:
+                - '201903.0'
+            - title: Migration Guide - Category Template Migration Console
+              url: /docs/scos/dev/migration-and-integration/module-migration-guides/mg-category-tem.html
+              include_versions:
+                - '201903.0'
+            - title: Migration Guide - ContentGui
+              url: /docs/scos/dev/migration-and-integration/module-migration-guides/mg-contentgui-2.html
+              include_versions:
+                - '201907.0'
+                - '202001.0'
+                - '202005.0'
+                - '202009.0'
+                - '202108.0'
+            - title: Migration Guide - CmsBlockGui
+              url: /docs/scos/dev/migration-and-integration/module-migration-guides/mg-cms-block-gu.html
+              include_versions:
+                - '202001.0'
+                - '202005.0'
+                - '202009.0'
+                - '202108.0'
+            - title: Migration Guide - PersistentCart
+              url: /docs/scos/dev/migration-and-integration/module-migration-guides/mg-persistent-c.html
+              include_versions:
+                - '201903.0'
+            - title: Migration Guide - CartExtension
+              url: /docs/scos/dev/migration-and-integration/module-migration-guides/mg-cart-extensi.html
+              include_versions:
+                - '201903.0'
+            - title: Migration Guide - StockGui
+              url: /docs/scos/dev/migration-and-integration/module-migration-guides/mg-stockgui.html
+              include_versions:
+                - '202001.0'
+                - '202005.0'
+                - '202009.0'
+                - '202108.0'
+            - title: Migration Guide - ProductQuantityStorage
+              url: /docs/scos/dev/migration-and-integration/module-migration-guides/mg-product-quan.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+                - '202005.0'
+                - '202108.0'
+            - title: Migration Guide - ProductOptionDiscountConnector
+              url: /docs/scos/dev/migration-and-integration/module-migration-guides/mg-product-opti.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+            - title: Migration Guide - Product Set GUI
+              url: /docs/scos/dev/migration-and-integration/module-migration-guides/mg-product-set-.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+                - '201907.0'
+            - title: Migration Guide - PriceProductVolume
+              url: /docs/scos/dev/migration-and-integration/module-migration-guides/mg-price-produc.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+            - title: Migration Guide - Price Cart Connector
+              url: /docs/scos/dev/migration-and-integration/module-migration-guides/mg-price-cart-c.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+                - '201907.0'
+            - title: Migration Guide - AvailabilityOfferConnector
+              url: /docs/scos/dev/migration-and-integration/module-migration-guides/mg-availability.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+                - '202009.0'
+                - '202108.0'
+            - title: Migration Guide - ProductPackagingUnitWidget
+              url: /docs/scos/dev/migration-and-integration/module-migration-guides/mg-product-pack.html
+              include_versions:
+                - '201811.0'
+                - '201907.0'
+                - '202009.0'
+            - title: Migration Guide - Product Validity
+              url: /docs/scos/dev/migration-and-integration/module-migration-guides/mg-product-vali.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+                - '201907.0'
+            - title: Migration Guide - CMS Block Category Connector Migration Console
+              url: /docs/scos/dev/migration-and-integration/module-migration-guides/mg-cms-block-ca.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+                - '201907.0'
+                - '202009.0'
+                - '202108.0'
+            - title: Migration Guide - CMS Block
+              url: /docs/scos/dev/migration-and-integration/module-migration-guides/mg-cms-block.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+                - '201907.0'
+            - title: Migration Guide - Product Label GUI
+              url: /docs/scos/dev/migration-and-integration/module-migration-guides/mg-product-labe.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+            - title: Migration Guide - Product Relation Collector
+              url: /docs/scos/dev/migration-and-integration/module-migration-guides/mg-product-rela.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+            - title: Migration Guide - Product Bundle
+              url: /docs/scos/dev/migration-and-integration/module-migration-guides/mg-product-bund.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+                - '201907.0'
+            - title: Migration Guide - ProductSearchWidget
+              url: /docs/scos/dev/migration-and-integration/module-migration-guides/mg-product-sear.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+                - '201907.0'
+                - '202009.0'
+            - title: Migration Guide - ProductMeasurementUnit
+              url: /docs/scos/dev/migration-and-integration/module-migration-guides/mg-product-meas.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+                - '202005.0'
+                - '202108.0'
+            - title: Migration Guide - CMS Collector
+              url: /docs/scos/dev/migration-and-integration/module-migration-guides/mg-cms-collecto.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+                - '201907.0'
+            - title: Migration Guide - CMS Block GUI
+              url: /docs/scos/dev/migration-and-integration/module-migration-guides/mg-cms-block-gu.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+                - '201907.0'
+            - title: Migration Guide - ProductOptionExporter
+              url: /docs/scos/dev/migration-and-integration/module-migration-guides/mg-product-opti.html
+              include_versions:
+                - '202005.0'
+            - title: Migration Guide - Validator
+              url: /docs/scos/dev/migration-and-integration/module-migration-guides/migration-guide.html
+              include_versions:
+                - '202005.0'
+            - title: Migration Guide - PriceProductVolumeGui
+              url: /docs/scos/dev/migration-and-integration/module-migration-guides/mg-price-produc.html
+              include_versions:
+                - '202005.0'
+                - '202108.0'
+            - title: Migration Guide - ShoppingListPage
+              url: /docs/scos/dev/migration-and-integration/module-migration-guides/mg-shopping-lis.html
+              include_versions:
+                - '202005.0'
+                - '202009.0'
+            - title: Migration Guide - ProductLabelGUI
+              url: /docs/scos/dev/migration-and-integration/module-migration-guides/mg-product-labe.html
+              include_versions:
+                - '202005.0'
+                - '202108.0'
+            - title: Migration Guide - QuoteRequestAgentPage
+              url: /docs/scos/dev/migration-and-integration/module-migration-guides/mg-quoterequest.html
+              include_versions:
+                - '202005.0'
+            - title: Migration Guide - ContentBanner
+              url: /docs/scos/dev/migration-and-integration/module-migration-guides/mg-contentbanne.html
+              include_versions:
+                - '202005.0'
+            - title: Migration Guide - CategoryGui
+              url: /docs/scos/dev/migration-and-integration/module-migration-guides/migration-guide-1-.html
+              include_versions:
+                - '202108.0'
+            - title: Migration Guide - ProductOptionCartConnector
+              url: /docs/scos/dev/migration-and-integration/module-migration-guides/mg-product-opti.html
+              include_versions:
+                - '202108.0'
+            - title: Migration Guide - HTTP
+              url: /docs/scos/dev/migration-and-integration/module-migration-guides/migration-guide.html
+              include_versions:
+                - '202108.0'
+            - title: Migration Guide - ProductPackagingUnitStorage
+              url: /docs/scos/dev/migration-and-integration/module-migration-guides/mg-product-pack.html
+              include_versions:
+                - '201903.0'
+                - '202108.0'
+            - title: Migration Guide - ShoppingList
+              url: /docs/scos/dev/migration-and-integration/module-migration-guides/mg-shopping-lis.html
+              include_versions:
+                - '202108.0'
+            - title: Migration Guide - QuoteRequestAgentWidget
+              url: /docs/scos/dev/migration-and-integration/module-migration-guides/mg-quoterequest.html
+              include_versions:
+                - '202108.0'
+            - title: Migration guide - publish and synchronization
+              url: /docs/scos/dev/migration-and-integration/module-migration-guides/mg-pub-and-sync.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+            - title: About migration guides
+              url: /docs/scos/dev/migration-and-integration/module-migration-guides/about-migration.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+            - title: Migration Guide - ProductQuantity
+              url: /docs/scos/dev/migration-and-integration/module-migration-guides/mg-product-quan.html
+              include_versions:
+                - '201907.0'
+                - '202009.0'
+            - title: Migration Guide - ProductLabelSearch
+              url: /docs/scos/dev/migration-and-integration/module-migration-guides/migration-guide.html
+              include_versions:
+                - '202009.0'
+            - title: Migration Guide - PriceProductScheduleGui
+              url: /docs/scos/dev/migration-and-integration/module-migration-guides/mg-price-produc.html
+              include_versions:
+                - '202009.0'
+            - title: Migration Guide - QuoteRequestPage
+              url: /docs/scos/dev/migration-and-integration/module-migration-guides/mg-quoterequest.html
+              include_versions:
+                - '202009.0'
+            - title: Migration Guide - ProductPageSearch
+              url: /docs/scos/dev/migration-and-integration/module-migration-guides/mg-product-page.html
+              include_versions:
+                - '201903.0'
+                - '201907.0'
+            - title: Migration Guide - Product Option Cart Connector
+              url: /docs/scos/dev/migration-and-integration/module-migration-guides/mg-product-opti.html
+              include_versions:
+                - '201907.0'
+            - title: Migration Guide - PriceProductStorage
+              url: /docs/scos/dev/migration-and-integration/module-migration-guides/mg-price-produc.html
+              include_versions:
+                - '201907.0'
+            - title: Migration Guide - AvailabilityGui
+              url: /docs/scos/dev/migration-and-integration/module-migration-guides/mg-availability.html
+              include_versions:
+                - '201907.0'
+            - title: Migration Guide - CMSGui
+              url: /docs/scos/dev/migration-and-integration/module-migration-guides/mg-cms-gui.html
+              include_versions:
+                - '201903.0'
+                - '201907.0'
+            - title: Migration Guide - Product Label
+              url: /docs/scos/dev/migration-and-integration/module-migration-guides/mg-product-labe.html
+              include_versions:
+                - '201907.0'
+            - title: Migration Guide - Product Relation
+              url: /docs/scos/dev/migration-and-integration/module-migration-guides/mg-product-rela.html
+              include_versions:
+                - '201907.0'
+            - title: Migration Guide - QuoteRequestAgent
+              url: /docs/scos/dev/migration-and-integration/module-migration-guides/mg-quoterequest.html
+              include_versions:
+                - '201907.0'
+        - title: Development tools
+          nested:
+            - title: Web Profiler Widget for Yves
+              url: /docs/scos/dev/migration-and-integration/development-tools/web-profiler-wi.html
+              include_versions:
+                - '202001.0'
+                - '202005.0'
+                - '202009.0'
+                - '202108.0'
+            - title: Web Profiler for Zed
+              url: /docs/scos/dev/migration-and-integration/development-tools/web-profiler.html
+              include_versions:
+                - '202001.0'
+                - '202005.0'
+                - '202009.0'
+                - '202108.0'
+            - title: SCSS linter integration guide
+              url: /docs/scos/dev/migration-and-integration/development-tools/scss-linter-int.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+            - title: Formatter integration guide
+              url: /docs/scos/dev/migration-and-integration/development-tools/formatter-integ.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+            - title: TS linter integration guide
+              url: /docs/scos/dev/migration-and-integration/development-tools/ts-linter-integ.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+        - title: DevOps Migration Guide 202001.0
+          url: /docs/scos/dev/migration-and-integration/devops-migratio.html
+          include_versions:
+            - '202001.0'
+            - '202005.0'
+        - title: About Migration and Integration Guides
+          url: /docs/scos/dev/migration-and-integration/about-migration.html
+          include_versions:
+            - '201811.0'
+            - '201903.0'
+            - '201907.0'
+            - '202001.0'
+            - '202005.0'
+        - title: Updating the legacy demoshop with SCOS
+          nested:
+            - title: Updating the Legacy Demoshop with SCOS
+              url: /docs/scos/dev/migration-and-integration/updating-the-legacy-demoshop-with-scos/about-updating.html
+              include_versions:
+                - '201903.0'
+            - title: Making the Legacy Demoshop Compatible with the Atomic Frontend
+              url: /docs/scos/dev/migration-and-integration/updating-the-legacy-demoshop-with-scos/demoshop-with-a.html
+              include_versions:
+                - '201903.0'
+            - title: Integrating Modular Frontend into Legacy Demoshop
+              url: /docs/scos/dev/migration-and-integration/updating-the-legacy-demoshop-with-scos/integrating-mod.html
+              include_versions:
+                - '201903.0'
+            - title: Making the Legacy Demoshop Compatible with Publish & Synchronize
+              url: /docs/scos/dev/migration-and-integration/updating-the-legacy-demoshop-with-scos/demoshop-with-p.html
+              include_versions:
+                - '201903.0'
+            - title: Making the Legacy Demoshop Compatible with the Modular Frontend
+              url: /docs/scos/dev/migration-and-integration/updating-the-legacy-demoshop-with-scos/demoshop-with-m.html
+              include_versions:
+                - '201903.0'
+            - title: Setting up ShopUiCompatibility Module in the Legacy Demoshop
+              url: /docs/scos/dev/migration-and-integration/updating-the-legacy-demoshop-with-scos/setting-up-shop.html
+              include_versions:
+                - '201903.0'
+            - title: Twig Compatibility- Legacy Demoshop vs SCOS
+              url: /docs/scos/dev/migration-and-integration/updating-the-legacy-demoshop-with-scos/twig-compatibil.html
+              include_versions:
+                - '201903.0'
+        - title: DevOps migration guide 202001.0
+          url: /docs/scos/dev/migration-and-integration/devops-migratio.html
+          include_versions:
+            - '202009.0'
+            - '202108.0'
+        - title: About migration and integration guides
+          url: /docs/scos/dev/migration-and-integration/about-migration.html
+          include_versions:
+            - '202009.0'
+            - '202108.0'
+    - title: Quick Add to Cart
+      nested:
+        - title: Quick Add to Cart- module relations
+          url: /docs/scos/dev/quick-add-to-cart/quick-add-to-ca.html
+          include_versions:
+            - '202009.0'
+    - title: Technology partners
+      nested:
+        - title: Order Management (ERPOMS)
+          nested:
+            - title: Tradebyte
+              url: /docs/scos/dev/technology-partners/order-management-erpoms/tradebyte.html
+              include_versions:
+                - '201903.0'
+            - title: NEKOM CC GmbH
+              url: /docs/scos/dev/technology-partners/order-management-erpoms/nekom.html
+              include_versions:
+                - '202001.0'
+                - '202005.0'
+                - '202009.0'
+                - '202108.0'
+            - title: Punchout Catalogs
+              nested:
+                - title: Eco- Punchout Catalogs + Product Bundles Feature Integration
+                  url: /docs/scos/dev/technology-partners/order-management-erpoms/punchout-catalogs/eco-punchout-ca.html
+                  include_versions:
+                    - '201903.0'
+                    - '201907.0'
+                    - '202001.0'
+                    - '202005.0'
+                    - '202009.0'
+                - title: Punchout Catalog Feature Integration
+                  url: /docs/scos/dev/technology-partners/order-management-erpoms/punchout-catalogs/punchout-catalo.html
+                  include_versions:
+                    - '201903.0'
+                    - '201907.0'
+                    - '202001.0'
+                    - '202005.0'
+                    - '202009.0'
+                - title: Eco- Punchout Catalogs + Product Bundles feature integration
+                  url: /docs/scos/dev/technology-partners/order-management-erpoms/punchout-catalogs/eco-punchout-ca.html
+                  include_versions:
+                    - '202108.0'
+                - title: Punchout Catalogs overview
+                  url: /docs/scos/dev/technology-partners/order-management-erpoms/punchout-catalogs/punchout-catalo.html
+                  include_versions:
+                    - '202108.0'
+            - title: Xentral
+              url: /docs/scos/dev/technology-partners/order-management-erpoms/xentral.html
+              include_versions:
+                - '202001.0'
+        - title: Marketplace Integrations
+          nested:
+            - title: ChannelPilot Marketplace
+              url: /docs/scos/dev/technology-partners/marketplace-integrations/channelpilot.html
+              include_versions:
+                - '201903.0'
+        - title: Finance & Accounting
+          nested:
+            - title: Nitrobox
+              url: /docs/scos/dev/technology-partners/finance-and-accounting/nitrobox.html
+              include_versions:
+                - '201903.0'
+            - title: CollectAI
+              url: /docs/scos/dev/technology-partners/finance-and-accounting/collect-ai.html
+              include_versions:
+                - '201903.0'
+        - title: 'Operational Tools (Monitoring, Legal, etc.)'
+          nested:
+            - title: PlusServer
+              url: /docs/scos/dev/technology-partners/operational-tools-monitoring-legal-etc./plusserver.html
+              include_versions:
+                - '201903.0'
+            - title: VSHN
+              url: /docs/scos/dev/technology-partners/operational-tools-monitoring-legal-etc./vshn.html
+              include_versions:
+                - '201903.0'
+            - title: Tideways
+              url: /docs/scos/dev/technology-partners/operational-tools-monitoring-legal-etc./tideways.html
+              include_versions:
+                - '201903.0'
+            - title: Shopmacher
+              url: /docs/scos/dev/technology-partners/operational-tools-monitoring-legal-etc./shopmacher.html
+              include_versions:
+                - '201903.0'
+            - title: Proclane
+              url: /docs/scos/dev/technology-partners/operational-tools-monitoring-legal-etc./proclane.html
+              include_versions:
+                - '201903.0'
+            - title: Usercentrics
+              url: /docs/scos/dev/technology-partners/operational-tools-monitoring-legal-etc./usercentrics.html
+              include_versions:
+                - '201903.0'
+            - title: New Relic
+              url: /docs/scos/dev/technology-partners/operational-tools-monitoring-legal-etc./new-relic.html
+              include_versions:
+                - '201903.0'
+            - title: Mindcurv
+              url: /docs/scos/dev/technology-partners/operational-tools-monitoring-legal-etc./mindcurv.html
+              include_versions:
+                - '201903.0'
+            - title: Loggly
+              url: /docs/scos/dev/technology-partners/operational-tools-monitoring-legal-etc./loggly-queue.html
+              include_versions:
+                - '201903.0'
+            - title: Data Virtuality
+              url: /docs/scos/dev/technology-partners/operational-tools-monitoring-legal-etc./datavirtuality.html
+              include_versions:
+                - '201903.0'
+            - title: common solutions
+              url: /docs/scos/dev/technology-partners/operational-tools-monitoring-legal-etc./common-solution.html
+              include_versions:
+                - '201903.0'
+        - title: Customer Service
+          nested:
+            - title: Dixa
+              url: /docs/scos/dev/technology-partners/customer-service/dixa.html
+              include_versions:
+                - '201903.0'
+            - title: Optimise it
+              url: /docs/scos/dev/technology-partners/customer-service/optimise-it.html
+              include_versions:
+                - '201903.0'
+            - title: iAdvize
+              url: /docs/scos/dev/technology-partners/customer-service/iadvize.html
+              include_versions:
+                - '201903.0'
+            - title: live chat service
+              url: /docs/scos/dev/technology-partners/customer-service/live-chat-servi.html
+              include_versions:
+                - '201903.0'
+        - title: Hosting Providers
+          nested:
+            - title: Claranet
+              url: /docs/scos/dev/technology-partners/hosting-providers/claranet.html
+              include_versions:
+                - '201903.0'
+            - title: Continum
+              url: /docs/scos/dev/technology-partners/hosting-providers/continum.html
+              include_versions:
+                - '201903.0'
+            - title: Root 360
+              url: /docs/scos/dev/technology-partners/hosting-providers/root360.html
+              include_versions:
+                - '201903.0'
+            - title: Metaways
+              url: /docs/scos/dev/technology-partners/hosting-providers/metaways.html
+              include_versions:
+                - '201903.0'
+            - title: Hosting Provider - Heroku
+              url: /docs/scos/dev/technology-partners/hosting-providers/hosting-provide.html
+              include_versions:
+                - '201903.0'
+        - title: Marketing & Conversion
+          nested:
+            - title: Personalization & Cross-Selling
+              nested:
+                - title: Econda
+                  nested:
+                    - title: Econda - Tracking
+                      url: /docs/scos/dev/technology-partners/marketing-and-conversion/personalization-and-cross-selling/econda/econda-tracking.html
+                      include_versions:
+                        - '201903.0'
+                    - title: Econda - Cross Sell
+                      url: /docs/scos/dev/technology-partners/marketing-and-conversion/personalization-and-cross-selling/econda/econda-cross-se.html
+                      include_versions:
+                        - '201903.0'
+                    - title: Econda - Frontend Integration
+                      url: /docs/scos/dev/technology-partners/marketing-and-conversion/personalization-and-cross-selling/econda/econda-frontend.html
+                      include_versions:
+                        - '201811.0'
+                        - '201903.0'
+                        - '201907.0'
+                        - '202001.0'
+                        - '202005.0'
+                    - title: Econda
+                      url: /docs/scos/dev/technology-partners/marketing-and-conversion/personalization-and-cross-selling/econda/econda.html
+                      include_versions:
+                        - '201903.0'
+                    - title: Econda - Exporting CSVs
+                      url: /docs/scos/dev/technology-partners/marketing-and-conversion/personalization-and-cross-selling/econda/econda-export-c.html
+                      include_versions:
+                        - '201903.0'
+                    - title: Econda - Integration into project
+                      url: /docs/scos/dev/technology-partners/marketing-and-conversion/personalization-and-cross-selling/econda/econda-integrat.html
+                      include_versions:
+                        - '202009.0'
+                        - '202108.0'
+                    - title: Econda - Installation and configuration
+                      url: /docs/scos/dev/technology-partners/marketing-and-conversion/personalization-and-cross-selling/econda/econda-installa.html
+                      include_versions:
+                        - '202009.0'
+                        - '202108.0'
+                - title: Nosto
+                  url: /docs/scos/dev/technology-partners/marketing-and-conversion/personalization-and-cross-selling/nosto.html
+                  include_versions:
+                    - '201903.0'
+                - title: Contentserv
+                  url: /docs/scos/dev/technology-partners/marketing-and-conversion/personalization-and-cross-selling/contentserv-1.html
+                  include_versions:
+                    - '201903.0'
+                - title: 8Select
+                  url: /docs/scos/dev/technology-partners/marketing-and-conversion/personalization-and-cross-selling/8select.html
+                  include_versions:
+                    - '201903.0'
+                - title: trbo
+                  url: /docs/scos/dev/technology-partners/marketing-and-conversion/personalization-and-cross-selling/trbo.html
+                  include_versions:
+                    - '201903.0'
+            - title: Customer Communication
+              nested:
+                - title: Episerver
+                  nested:
+                    - title: Episerver
+                      url: /docs/scos/dev/technology-partners/marketing-and-conversion/customer-communication/episerver/episerver.html
+                      include_versions:
+                        - '201903.0'
+                    - title: Episerver - Installation and Configuration
+                      url: /docs/scos/dev/technology-partners/marketing-and-conversion/customer-communication/episerver/episerver-insta.html
+                      include_versions:
+                        - '201903.0'
+                    - title: Episerver - Integration into a project
+                      url: /docs/scos/dev/technology-partners/marketing-and-conversion/customer-communication/episerver/episerver-integ.html
+                      include_versions:
+                        - '202009.0'
+                        - '202108.0'
+                    - title: Technical details and HowTos
+                      nested:
+                        - title: Episerver - Order referenced commands
+                          url: /docs/scos/dev/technology-partners/marketing-and-conversion/customer-communication/episerver/technical-details-and-howtos/episerver-order.html
+                          include_versions:
+                            - '202009.0'
+                            - '202108.0'
+                        - title: Episerver - API Requests
+                          url: /docs/scos/dev/technology-partners/marketing-and-conversion/customer-communication/episerver/technical-details-and-howtos/episerver-api-r.html
+                          include_versions:
+                            - '202009.0'
+                            - '202108.0'
+                - title: Dotdigital
+                  url: /docs/scos/dev/technology-partners/marketing-and-conversion/customer-communication/dotdigital.html
+                  include_versions:
+                    - '201903.0'
+                - title: Inxmail
+                  url: /docs/scos/dev/technology-partners/marketing-and-conversion/customer-communication/inxmail.html
+                  include_versions:
+                    - '201903.0'
+            - title: AB Testing & Performance
+              nested:
+                - title: AB Tasty
+                  url: /docs/scos/dev/technology-partners/marketing-and-conversion/ab-testing-and-performance/ab-tasty.html
+                  include_versions:
+                    - '201903.0'
+                - title: Baqend
+                  url: /docs/scos/dev/technology-partners/marketing-and-conversion/ab-testing-and-performance/baqend.html
+                  include_versions:
+                    - '201903.0'
+            - title: Customer Retention & Loyalty
+              nested:
+                - title: Zenloop
+                  url: /docs/scos/dev/technology-partners/marketing-and-conversion/customer-retention-and-loyalty/zenloop.html
+                  include_versions:
+                    - '201903.0'
+                - title: Namogoo
+                  url: /docs/scos/dev/technology-partners/marketing-and-conversion/customer-retention-and-loyalty/namogoo.html
+                  include_versions:
+                    - '201903.0'
+                - title: Trustpilot
+                  url: /docs/scos/dev/technology-partners/marketing-and-conversion/customer-retention-and-loyalty/trustpilot.html
+                  include_versions:
+                    - '201903.0'
+            - title: Analytics
+              nested:
+                - title: FACT-Finder
+                  nested:
+                    - title: FACT-Finder - NG
+                      url: /docs/scos/dev/technology-partners/marketing-and-conversion/analytics/fact-finder/fact-finder-ng.html
+                      include_versions:
+                        - '201903.0'
+                    - title: FACT-Finder - Exporting CSVs
+                      url: /docs/scos/dev/technology-partners/marketing-and-conversion/analytics/fact-finder/search-factfind.html
+                      include_versions:
+                        - '201811.0'
+                        - '201903.0'
+                        - '201907.0'
+                        - '202001.0'
+                        - '202005.0'
+                    - title: FACT-Finder
+                      url: /docs/scos/dev/technology-partners/marketing-and-conversion/analytics/fact-finder/factfinder.html
+                      include_versions:
+                        - '201903.0'
+                    - title: FACT-Finder - Suggest
+                      url: /docs/scos/dev/technology-partners/marketing-and-conversion/analytics/fact-finder/search-factfind.html
+                      include_versions:
+                        - '202009.0'
+                        - '202108.0'
+                    - title: FACT-Finder - Installation and configuration
+                      url: /docs/scos/dev/technology-partners/marketing-and-conversion/analytics/fact-finder/fact-finder-ins.html
+                      include_versions:
+                        - '202009.0'
+                        - '202108.0'
+                    - title: FACT-Finder - Integration into project
+                      url: /docs/scos/dev/technology-partners/marketing-and-conversion/analytics/fact-finder/fact-finder-int.html
+                      include_versions:
+                        - '202009.0'
+                        - '202108.0'
+                - title: Minubo
+                  url: /docs/scos/dev/technology-partners/marketing-and-conversion/analytics/minubo.html
+                  include_versions:
+                    - '201903.0'
+                - title: Fact Finder Web Components
+                  url: /docs/scos/dev/technology-partners/marketing-and-conversion/analytics/fact-finder-web.html
+                  include_versions:
+                    - '201903.0'
+                - title: Haensel AMS
+                  url: /docs/scos/dev/technology-partners/marketing-and-conversion/analytics/haensel-ams.html
+                  include_versions:
+                    - '201903.0'
+                - title: Mindlab
+                  url: /docs/scos/dev/technology-partners/marketing-and-conversion/analytics/mindlab.html
+                  include_versions:
+                    - '201903.0'
+                - title: ChannelPilot Analytics
+                  url: /docs/scos/dev/technology-partners/marketing-and-conversion/analytics/channelpilot-an.html
+                  include_versions:
+                    - '201903.0'
+        - title: Payment Partners
+          nested:
+            - title: BS Payone
+              nested:
+                - title: SCOS Integration
+                  nested:
+                    - title: PayOne - PayPal Express Checkout Payment
+                      url: /docs/scos/dev/technology-partners/payment-partners/bs-payone/scos-integration/payone-paypal-e.html
+                    - title: PayOne - Risk Check and Address Check
+                      url: /docs/scos/dev/technology-partners/payment-partners/bs-payone/scos-integration/payone-risk-che.html
+                      include_versions:
+                        - '201903.0'
+                    - title: PayOne - Integration into the SCOS Project
+                      url: /docs/scos/dev/technology-partners/payment-partners/bs-payone/scos-integration/payone-integrat.html
+                      include_versions:
+                        - '201903.0'
+                    - title: PayOne - Cash on Delivery
+                      url: /docs/scos/dev/technology-partners/payment-partners/bs-payone/scos-integration/payone-cash-on-.html
+                      include_versions:
+                        - '201903.0'
+                    - title: PayOne - PayPal Express Checkout payment
+                      url: /docs/scos/dev/technology-partners/payment-partners/bs-payone/scos-integration/payone-paypal-e.html
+                      include_versions:
+                        - '202108.0'
+                - title: BS Payone
+                  url: /docs/scos/dev/technology-partners/payment-partners/bs-payone/payone-v1-1.html
+                  include_versions:
+                    - '201903.0'
+                - title: Legacy Demoshop integration
+                  nested:
+                    - title: PayOne - Credit Card Payment
+                      url: /docs/scos/dev/technology-partners/payment-partners/bs-payone/legacy-demoshop-integration/payone-credit-c.html
+                      include_versions:
+                        - '201811.0'
+                        - '201903.0'
+                        - '201907.0'
+                        - '202001.0'
+                        - '202005.0'
+                    - title: PayOne - Prepayment
+                      url: /docs/scos/dev/technology-partners/payment-partners/bs-payone/legacy-demoshop-integration/payone-prepayme.html
+                      include_versions:
+                        - '201811.0'
+                        - '201903.0'
+                        - '201907.0'
+                        - '202001.0'
+                        - '202005.0'
+                    - title: PayOne - Invoice Payment
+                      url: /docs/scos/dev/technology-partners/payment-partners/bs-payone/legacy-demoshop-integration/payone-invoice.html
+                      include_versions:
+                        - '201811.0'
+                        - '201903.0'
+                        - '201907.0'
+                        - '202001.0'
+                        - '202005.0'
+                    - title: PayOne - PayPal Express Checkout Payment
+                      url: /docs/scos/dev/technology-partners/payment-partners/bs-payone/legacy-demoshop-integration/payone-paypal-e.html
+                      include_versions:
+                        - '201811.0'
+                        - '201903.0'
+                        - '201907.0'
+                        - '202001.0'
+                        - '202005.0'
+                    - title: PayOne - Direct Debit Payment
+                      url: /docs/scos/dev/technology-partners/payment-partners/bs-payone/legacy-demoshop-integration/payone-direct-d.html
+                      include_versions:
+                        - '201811.0'
+                        - '201903.0'
+                        - '201907.0'
+                        - '202001.0'
+                        - '202005.0'
+                    - title: PayOne - Authorization and Preauthorization Capture
+                        Flows
+                      url: /docs/scos/dev/technology-partners/payment-partners/bs-payone/legacy-demoshop-integration/payone-authoriz.html
+                      include_versions:
+                        - '201903.0'
+                    - title: PayOne - Security Invoice Payment
+                      url: /docs/scos/dev/technology-partners/payment-partners/bs-payone/legacy-demoshop-integration/payone-security.html
+                      include_versions:
+                        - '201811.0'
+                        - '201903.0'
+                        - '201907.0'
+                        - '202001.0'
+                        - '202005.0'
+                    - title: PayOne - Integration into the Legacy Demoshop Project
+                      url: /docs/scos/dev/technology-partners/payment-partners/bs-payone/legacy-demoshop-integration/payone-integrat.html
+                      include_versions:
+                        - '201903.0'
+                    - title: PayOne - Online Transfer Payment
+                      url: /docs/scos/dev/technology-partners/payment-partners/bs-payone/legacy-demoshop-integration/payone-online-t.html
+                      include_versions:
+                        - '201811.0'
+                        - '201903.0'
+                        - '201907.0'
+                        - '202001.0'
+                        - '202005.0'
+                    - title: PayOne - Paypal Payment
+                      url: /docs/scos/dev/technology-partners/payment-partners/bs-payone/legacy-demoshop-integration/payone-paypal.html
+                      include_versions:
+                        - '201811.0'
+                        - '201903.0'
+                        - '201907.0'
+                        - '202001.0'
+                        - '202005.0'
+                    - title: PayOne - Facade
+                      url: /docs/scos/dev/technology-partners/payment-partners/bs-payone/legacy-demoshop-integration/payone-facade.html
+                      include_versions:
+                        - '201903.0'
+                    - title: 'PayOne - State Machine Commands, Conditions and Events'
+                      url: /docs/scos/dev/technology-partners/payment-partners/bs-payone/legacy-demoshop-integration/payone-state-ma.html
+                      include_versions:
+                        - '201903.0'
+                    - title: PayOne - Payment methods
+                      nested:
+                        - title: PayOne - Credit Card Payment
+                          url: /docs/scos/dev/technology-partners/payment-partners/bs-payone/legacy-demoshop-integration/payone-payment-methods/payone-credit-c.html
+                          include_versions:
+                            - '202009.0'
+                            - '202108.0'
+                        - title: PayOne - Prepayment
+                          url: /docs/scos/dev/technology-partners/payment-partners/bs-payone/legacy-demoshop-integration/payone-payment-methods/payone-prepayme.html
+                          include_versions:
+                            - '202009.0'
+                            - '202108.0'
+                        - title: PayOne - Invoice Payment
+                          url: /docs/scos/dev/technology-partners/payment-partners/bs-payone/legacy-demoshop-integration/payone-payment-methods/payone-invoice.html
+                          include_versions:
+                            - '202009.0'
+                            - '202108.0'
+                        - title: PayOne - PayPal Express Checkout Payment
+                          url: /docs/scos/dev/technology-partners/payment-partners/bs-payone/legacy-demoshop-integration/payone-payment-methods/payone-paypal-e.html
+                          include_versions:
+                            - '202009.0'
+                            - '202108.0'
+                        - title: PayOne - Direct Debit Payment
+                          url: /docs/scos/dev/technology-partners/payment-partners/bs-payone/legacy-demoshop-integration/payone-payment-methods/payone-direct-d.html
+                          include_versions:
+                            - '202009.0'
+                            - '202108.0'
+                        - title: PayOne - Security Invoice Payment
+                          url: /docs/scos/dev/technology-partners/payment-partners/bs-payone/legacy-demoshop-integration/payone-payment-methods/payone-security.html
+                          include_versions:
+                            - '202009.0'
+                            - '202108.0'
+                        - title: PayOne - Online Transfer Payment
+                          url: /docs/scos/dev/technology-partners/payment-partners/bs-payone/legacy-demoshop-integration/payone-payment-methods/payone-online-t.html
+                          include_versions:
+                            - '202009.0'
+                            - '202108.0'
+                        - title: PayOne - Paypal Payment
+                          url: /docs/scos/dev/technology-partners/payment-partners/bs-payone/legacy-demoshop-integration/payone-payment-methods/payone-paypal.html
+                          include_versions:
+                            - '202009.0'
+                            - '202108.0'
+            - title: Billpay
+              nested:
+                - title: Billpay - Invoice Payment in Preauthorize Mode
+                  url: /docs/scos/dev/technology-partners/payment-partners/billpay/billpay-payment.html
+                  include_versions:
+                    - '201903.0'
+                - title: Billpay - Integration
+                  url: /docs/scos/dev/technology-partners/payment-partners/billpay/billpay-integra.html
+                  include_versions:
+                    - '201903.0'
+                - title: Billpay
+                  url: /docs/scos/dev/technology-partners/payment-partners/billpay/billpay.html
+                  include_versions:
+                    - '201903.0'
+            - title: Klarna
+              nested:
+                - title: Klarna - Payment Workflow
+                  url: /docs/scos/dev/technology-partners/payment-partners/klarna/klarna-payment-.html
+                  include_versions:
+                    - '201811.0'
+                    - '201903.0'
+                    - '201907.0'
+                    - '202001.0'
+                    - '202005.0'
+                - title: Klarna
+                  url: /docs/scos/dev/technology-partners/payment-partners/klarna/klarna.html
+                  include_versions:
+                    - '201903.0'
+                - title: Klarna - Part Payment Flexible
+                  url: /docs/scos/dev/technology-partners/payment-partners/klarna/klarna-part-pay.html
+                  include_versions:
+                    - '201811.0'
+                    - '201903.0'
+                    - '201907.0'
+                    - '202001.0'
+                    - '202005.0'
+                - title: Klarna - State Machine Commands and Conditions
+                  url: /docs/scos/dev/technology-partners/payment-partners/klarna/klarna-state-ma.html
+                  include_versions:
+                    - '201811.0'
+                    - '201903.0'
+                    - '201907.0'
+                    - '202001.0'
+                    - '202005.0'
+                - title: Klarna - Invoice Pay in 14 days
+                  url: /docs/scos/dev/technology-partners/payment-partners/klarna/klarna-invoice-.html
+                  include_versions:
+                    - '201811.0'
+                    - '201903.0'
+                    - '201907.0'
+                    - '202001.0'
+                    - '202005.0'
+                - title: Technical details and HowTos
+                  nested:
+                    - title: Klarna - Payment Workflow
+                      url: /docs/scos/dev/technology-partners/payment-partners/klarna/technical-details-and-howtos/klarna-payment-.html
+                      include_versions:
+                        - '202009.0'
+                        - '202108.0'
+                    - title: Klarna - Part Payment Flexible
+                      url: /docs/scos/dev/technology-partners/payment-partners/klarna/technical-details-and-howtos/klarna-part-pay.html
+                      include_versions:
+                        - '202009.0'
+                        - '202108.0'
+                    - title: Klarna - State Machine Commands and Conditions
+                      url: /docs/scos/dev/technology-partners/payment-partners/klarna/technical-details-and-howtos/klarna-state-ma.html
+                      include_versions:
+                        - '202009.0'
+                        - '202108.0'
+                    - title: Klarna - Invoice Pay in 14 days
+                      url: /docs/scos/dev/technology-partners/payment-partners/klarna/technical-details-and-howtos/klarna-invoice-.html
+                      include_versions:
+                        - '202009.0'
+                        - '202108.0'
+            - title: Braintree
+              nested:
+                - title: SCOS Integration
+                  nested:
+                    - title: Braintree - Workflow for SCOS
+                      url: /docs/scos/dev/technology-partners/payment-partners/braintree/scos-integration/braintree-workf.html
+                      include_versions:
+                        - '201811.0'
+                        - '201903.0'
+                        - '201907.0'
+                        - '202001.0'
+                    - title: Braintree - Configuration for SCOS
+                      url: /docs/scos/dev/technology-partners/payment-partners/braintree/scos-integration/braintree-confi.html
+                      include_versions:
+                        - '201811.0'
+                        - '201903.0'
+                        - '201907.0'
+                        - '202001.0'
+                    - title: Braintree - Performing Requests for SCOS
+                      url: /docs/scos/dev/technology-partners/payment-partners/braintree/scos-integration/braintree-perfo.html
+                      include_versions:
+                        - '201811.0'
+                        - '201903.0'
+                        - '201907.0'
+                        - '202001.0'
+                - title: Braintree
+                  url: /docs/scos/dev/technology-partners/payment-partners/braintree/braintree.html
+                  include_versions:
+                    - '201903.0'
+                - title: Legacy Demoshop integration
+                  nested:
+                    - title: Braintree - Workflow for Legacy Demoshop
+                      url: /docs/scos/dev/technology-partners/payment-partners/braintree/legacy-demoshop-integration/braintree-workf.html
+                      include_versions:
+                        - '201811.0'
+                        - '201903.0'
+                        - '201907.0'
+                        - '202001.0'
+                    - title: Braintree - Configuration for the Legacy Demoshop
+                      url: /docs/scos/dev/technology-partners/payment-partners/braintree/legacy-demoshop-integration/braintree-confi.html
+                      include_versions:
+                        - '201811.0'
+                        - '201903.0'
+                        - '201907.0'
+                        - '202001.0'
+                    - title: Braintree - Performing Requests for the Legacy Demoshop
+                      url: /docs/scos/dev/technology-partners/payment-partners/braintree/legacy-demoshop-integration/braintree-reque.html
+                      include_versions:
+                        - '201811.0'
+                        - '201903.0'
+                        - '201907.0'
+                        - '202001.0'
+                - title: Integration
+                  nested:
+                    - title: Braintree - Workflow
+                      url: /docs/scos/dev/technology-partners/payment-partners/braintree/integration/braintree-workf.html
+                      include_versions:
+                        - '202005.0'
+                    - title: Braintree - Configuration
+                      url: /docs/scos/dev/technology-partners/payment-partners/braintree/integration/braintree-confi.html
+                      include_versions:
+                        - '202005.0'
+                    - title: Braintree - Performing Requests
+                      url: /docs/scos/dev/technology-partners/payment-partners/braintree/integration/braintree-perfo.html
+                      include_versions:
+                        - '202005.0'
+                - title: Braintree - Technical Details and HowTos
+                  nested:
+                    - title: Braintree - Workflow
+                      url: /docs/scos/dev/technology-partners/payment-partners/braintree/braintree-technical-details-and-howtos/braintree-workf.html
+                      include_versions:
+                        - '202009.0'
+                        - '202108.0'
+                    - title: Braintree - Performing Requests
+                      url: /docs/scos/dev/technology-partners/payment-partners/braintree/braintree-technical-details-and-howtos/braintree-perfo.html
+                      include_versions:
+                        - '202009.0'
+                        - '202108.0'
+                - title: Braintree - Installation and configuration
+                  url: /docs/scos/dev/technology-partners/payment-partners/braintree/braintree-confi.html
+                  include_versions:
+                    - '202009.0'
+                    - '202108.0'
+                - title: Braintree - Integration into a project
+                  url: /docs/scos/dev/technology-partners/payment-partners/braintree/braintree-integ.html
+                  include_versions:
+                    - '202009.0'
+                    - '202108.0'
+            - title: Amazon Pay
+              nested:
+                - title: SCOS Integration
+                  nested:
+                    - title: Amazon Pay - Sandbox Simulations
+                      url: /docs/scos/dev/technology-partners/payment-partners/amazon-pay/scos-integration/amazon-sandbox-.html
+                      include_versions:
+                        - '201903.0'
+                    - title: Amazon Pay - Configuration for the SCOS
+                      url: /docs/scos/dev/technology-partners/payment-partners/amazon-pay/scos-integration/amazon-pay-conf.html
+                      include_versions:
+                        - '201903.0'
+                    - title: Amazon Pay - State Machine
+                      url: /docs/scos/dev/technology-partners/payment-partners/amazon-pay/scos-integration/amazon-pay-stat.html
+                      include_versions:
+                        - '201903.0'
+                    - title: Amazon Pay - Obtaining an Amazon Order Reference and
+                        Information About Shipping Addresses
+                      url: /docs/scos/dev/technology-partners/payment-partners/amazon-pay/scos-integration/amazon-order-re.html
+                      include_versions:
+                        - '201903.0'
+                    - title: Amazon Pay - API
+                      url: /docs/scos/dev/technology-partners/payment-partners/amazon-pay/scos-integration/amazon-pay-api.html
+                      include_versions:
+                        - '201903.0'
+                - title: Amazon Pay
+                  url: /docs/scos/dev/technology-partners/payment-partners/amazon-pay/amazon-pay.html
+                  include_versions:
+                    - '201903.0'
+                - title: Legacy Demoshop integration
+                  nested:
+                    - title: Amazon Pay - API
+                      url: /docs/scos/dev/technology-partners/payment-partners/amazon-pay/legacy-demoshop-integration/amazon-pay-api-.html
+                      include_versions:
+                        - '201903.0'
+                    - title: Amazon Pay - Email Notifications
+                      url: /docs/scos/dev/technology-partners/payment-partners/amazon-pay/legacy-demoshop-integration/amazon-pay-emai.html
+                      include_versions:
+                        - '201903.0'
+                    - title: Amazon Pay - Rendering a “Pay with Amazon” Button on the
+                        Cart Page
+                      url: /docs/scos/dev/technology-partners/payment-partners/amazon-pay/legacy-demoshop-integration/amazon-pay-rend.html
+                      include_versions:
+                        - '201903.0'
+                    - title: Amazon Pay - Order Reference and Information about
+                        Shipping Addresses
+                      url: /docs/scos/dev/technology-partners/payment-partners/amazon-pay/legacy-demoshop-integration/amazon-pay-orde.html
+                      include_versions:
+                        - '201903.0'
+                    - title: Amazon Pay - Refund
+                      url: /docs/scos/dev/technology-partners/payment-partners/amazon-pay/legacy-demoshop-integration/amazon-pay-refu.html
+                      include_versions:
+                        - '201903.0'
+                    - title: Amazon Pay - Configuration for the Legacy Demoshop
+                      url: /docs/scos/dev/technology-partners/payment-partners/amazon-pay/legacy-demoshop-integration/amazon-pay-conf.html
+                      include_versions:
+                        - '201903.0'
+                    - title: Amazon Pay - State Machine
+                      url: /docs/scos/dev/technology-partners/payment-partners/amazon-pay/legacy-demoshop-integration/amazon-pay-stat.html
+                      include_versions:
+                        - '201903.0'
+                    - title: Amazon Pay - Support of Bundled Products
+                      url: /docs/scos/dev/technology-partners/payment-partners/amazon-pay/legacy-demoshop-integration/amazon-pay-supp.html
+                      include_versions:
+                        - '201903.0'
+                    - title: Amazon Pay - Sandbox Simulations
+                      url: /docs/scos/dev/technology-partners/payment-partners/amazon-pay/legacy-demoshop-integration/amazon-pay-simu.html
+                      include_versions:
+                        - '201903.0'
+            - title: Heidelpay
+              nested:
+                - title: SCOS Integration
+                  nested:
+                    - title: Heidelpay - Configuration for SCOS
+                      url: /docs/scos/dev/technology-partners/payment-partners/heidelpay/scos-integration/heidelpay-confi.html
+                      include_versions:
+                        - '201903.0'
+                    - title: Heidelpay - Integration into SCOS
+                      url: /docs/scos/dev/technology-partners/payment-partners/heidelpay/scos-integration/heidelpay-integ.html
+                      include_versions:
+                        - '201903.0'
+                - title: Heidelpay - Installation
+                  url: /docs/scos/dev/technology-partners/payment-partners/heidelpay/heidelpay-insta.html
+                  include_versions:
+                    - '201903.0'
+                - title: Heidelpay - Direct Debit
+                  url: /docs/scos/dev/technology-partners/payment-partners/heidelpay/heidelpay-direc.html
+                  include_versions:
+                    - '201811.0'
+                    - '201903.0'
+                    - '201907.0'
+                    - '202001.0'
+                    - '202005.0'
+                - title: Heidelpay
+                  url: /docs/scos/dev/technology-partners/payment-partners/heidelpay/heidelpay.html
+                  include_versions:
+                    - '201903.0'
+                - title: Heidelpay - Paypal Debit Workflow
+                  url: /docs/scos/dev/technology-partners/payment-partners/heidelpay/heidelpay-paypa.html
+                  include_versions:
+                    - '201811.0'
+                    - '201903.0'
+                    - '201907.0'
+                    - '202001.0'
+                    - '202005.0'
+                - title: Heidelpay - Split-payment Marketplace
+                  url: /docs/scos/dev/technology-partners/payment-partners/heidelpay/heidelpay-split.html
+                  include_versions:
+                    - '201811.0'
+                    - '201903.0'
+                    - '201907.0'
+                    - '202001.0'
+                    - '202005.0'
+                - title: Heidelpay - Credit Card Secure
+                  url: /docs/scos/dev/technology-partners/payment-partners/heidelpay/heidelpay-credi.html
+                  include_versions:
+                    - '201811.0'
+                    - '201903.0'
+                    - '201907.0'
+                    - '202001.0'
+                    - '202005.0'
+                - title: Heidelpay - iDeal
+                  url: /docs/scos/dev/technology-partners/payment-partners/heidelpay/heidelpay-ideal.html
+                  include_versions:
+                    - '201811.0'
+                    - '201903.0'
+                    - '201907.0'
+                    - '202001.0'
+                    - '202005.0'
+                - title: Heidelpay - Paypal Authorize
+                  url: /docs/scos/dev/technology-partners/payment-partners/heidelpay/heidelpay-autho.html
+                  include_versions:
+                    - '201811.0'
+                    - '201903.0'
+                    - '201907.0'
+                    - '202001.0'
+                    - '202005.0'
+                - title: Heidelpay - Integration into the Legacy Demoshop
+                  url: /docs/scos/dev/technology-partners/payment-partners/heidelpay/heidelpay-integ.html
+                  include_versions:
+                    - '201811.0'
+                    - '201903.0'
+                    - '201907.0'
+                    - '202001.0'
+                - title: Heidelpay - Easy Credit
+                  url: /docs/scos/dev/technology-partners/payment-partners/heidelpay/heidelpay-easy-.html
+                  include_versions:
+                    - '201811.0'
+                    - '201903.0'
+                    - '201907.0'
+                    - '202001.0'
+                    - '202005.0'
+                - title: Heidelpay - Workflow for Errors
+                  url: /docs/scos/dev/technology-partners/payment-partners/heidelpay/heidelpay-error.html
+                  include_versions:
+                    - '201811.0'
+                    - '201903.0'
+                    - '201907.0'
+                    - '202001.0'
+                    - '202005.0'
+                - title: Heidelpay - Invoice Secured B2C
+                  url: /docs/scos/dev/technology-partners/payment-partners/heidelpay/heidelpay-invoi.html
+                  include_versions:
+                    - '201811.0'
+                    - '201903.0'
+                    - '201907.0'
+                    - '202001.0'
+                    - '202005.0'
+                - title: Heidelpay - Sofort (Online Transfer)
+                  url: /docs/scos/dev/technology-partners/payment-partners/heidelpay/heidelpay-sofor.html
+                  include_versions:
+                    - '202001.0'
+                    - '202005.0'
+                - title: Heidelay - Sofort (Online Transfer)
+                  url: /docs/scos/dev/technology-partners/payment-partners/heidelpay/heidelpay-sofor.html
+                  include_versions:
+                    - '201811.0'
+                    - '201903.0'
+                    - '201907.0'
+                - title: Heidelpay - Payment methods
+                  nested:
+                    - title: Heidelpay - Direct Debit
+                      url: /docs/scos/dev/technology-partners/payment-partners/heidelpay/heidelpay-payment-methods/heidelpay-direc.html
+                      include_versions:
+                        - '202009.0'
+                        - '202108.0'
+                    - title: Heidelpay - Paypal Debit Workflow
+                      url: /docs/scos/dev/technology-partners/payment-partners/heidelpay/heidelpay-payment-methods/heidelpay-paypa.html
+                      include_versions:
+                        - '202009.0'
+                        - '202108.0'
+                    - title: Heidelpay - Split-payment Marketplace
+                      url: /docs/scos/dev/technology-partners/payment-partners/heidelpay/heidelpay-payment-methods/heidelpay-split.html
+                      include_versions:
+                        - '202009.0'
+                        - '202108.0'
+                    - title: Heidelpay - Credit Card Secure
+                      url: /docs/scos/dev/technology-partners/payment-partners/heidelpay/heidelpay-payment-methods/heidelpay-credi.html
+                      include_versions:
+                        - '202009.0'
+                        - '202108.0'
+                    - title: Heidelpay - iDeal
+                      url: /docs/scos/dev/technology-partners/payment-partners/heidelpay/heidelpay-payment-methods/heidelpay-ideal.html
+                      include_versions:
+                        - '202009.0'
+                        - '202108.0'
+                    - title: Heidelpay - Paypal Authorize
+                      url: /docs/scos/dev/technology-partners/payment-partners/heidelpay/heidelpay-payment-methods/heidelpay-autho.html
+                      include_versions:
+                        - '202009.0'
+                        - '202108.0'
+                    - title: Heidelpay - Easy Credit
+                      url: /docs/scos/dev/technology-partners/payment-partners/heidelpay/heidelpay-payment-methods/heidelpay-easy-.html
+                      include_versions:
+                        - '202009.0'
+                        - '202108.0'
+                    - title: Heidelpay - Invoice Secured B2C
+                      url: /docs/scos/dev/technology-partners/payment-partners/heidelpay/heidelpay-payment-methods/heidelpay-invoi.html
+                      include_versions:
+                        - '202009.0'
+                        - '202108.0'
+                    - title: Heidelpay - Sofort (Online Transfer)
+                      url: /docs/scos/dev/technology-partners/payment-partners/heidelpay/heidelpay-payment-methods/heidelpay-sofor.html
+                      include_versions:
+                        - '202009.0'
+                        - '202108.0'
+                - title: Technical details and HowTos
+                  nested:
+                    - title: Heidelpay -  OMS Workflow
+                      url: /docs/scos/dev/technology-partners/payment-partners/heidelpay/technical-details-and-howtos/heidelpay-oms-w.html
+                      include_versions:
+                        - '202009.0'
+                        - '202108.0'
+                    - title: Heidelpay - Workflow for Errors
+                      url: /docs/scos/dev/technology-partners/payment-partners/heidelpay/technical-details-and-howtos/heidelpay-error.html
+                      include_versions:
+                        - '202009.0'
+                        - '202108.0'
+            - title: RatePay
+              nested:
+                - title: RatePay - How to Disable Address Updates from the Backend
+                    Application
+                  url: /docs/scos/dev/technology-partners/payment-partners/ratepay/ratepay-disable.html
+                  include_versions:
+                    - '201811.0'
+                    - '201903.0'
+                    - '201907.0'
+                    - '202001.0'
+                    - '202005.0'
+                - title: RatePay - Facade
+                  url: /docs/scos/dev/technology-partners/payment-partners/ratepay/ratepay-facade.html
+                  include_versions:
+                    - '201811.0'
+                    - '201903.0'
+                    - '201907.0'
+                    - '202001.0'
+                    - '202005.0'
+                - title: RatePay - Prepayment
+                  url: /docs/scos/dev/technology-partners/payment-partners/ratepay/ratepay-prepaym.html
+                  include_versions:
+                    - '201811.0'
+                    - '201903.0'
+                    - '201907.0'
+                    - '202001.0'
+                    - '202005.0'
+                - title: RatePay - Installment
+                  url: /docs/scos/dev/technology-partners/payment-partners/ratepay/ratepay-install.html
+                  include_versions:
+                    - '201811.0'
+                    - '201903.0'
+                    - '201907.0'
+                    - '202001.0'
+                    - '202005.0'
+                - title: RatePay - Invoice
+                  url: /docs/scos/dev/technology-partners/payment-partners/ratepay/ratepay-invoice.html
+                  include_versions:
+                    - '201811.0'
+                    - '201903.0'
+                    - '201907.0'
+                    - '202001.0'
+                    - '202005.0'
+                - title: RatePay - Payment Workflow
+                  url: /docs/scos/dev/technology-partners/payment-partners/ratepay/ratepay-payment.html
+                  include_versions:
+                    - '201811.0'
+                    - '201903.0'
+                    - '201907.0'
+                    - '202001.0'
+                    - '202005.0'
+                - title: RatePay - Direct Debit
+                  url: /docs/scos/dev/technology-partners/payment-partners/ratepay/ratepay-direct-.html
+                  include_versions:
+                    - '201811.0'
+                    - '201903.0'
+                    - '201907.0'
+                    - '202001.0'
+                    - '202005.0'
+                - title: RatePay- Core Module Structure Diagram
+                  url: /docs/scos/dev/technology-partners/payment-partners/ratepay/ratepay-structu.html
+                  include_versions:
+                    - '201903.0'
+                - title: RatePay - State Machine Commands and Conditions
+                  url: /docs/scos/dev/technology-partners/payment-partners/ratepay/ratepay-state-m.html
+                  include_versions:
+                    - '201811.0'
+                    - '201903.0'
+                    - '201907.0'
+                    - '202001.0'
+                    - '202005.0'
+                - title: RatePay
+                  url: /docs/scos/dev/technology-partners/payment-partners/ratepay/ratepay.html
+                  include_versions:
+                    - '201903.0'
+                - title: RatePay - Payment methods
+                  nested:
+                    - title: RatePay - Prepayment
+                      url: /docs/scos/dev/technology-partners/payment-partners/ratepay/ratepay-payment-methods/ratepay-prepaym.html
+                      include_versions:
+                        - '202009.0'
+                        - '202108.0'
+                    - title: RatePay - Installment
+                      url: /docs/scos/dev/technology-partners/payment-partners/ratepay/ratepay-payment-methods/ratepay-install.html
+                      include_versions:
+                        - '202009.0'
+                        - '202108.0'
+                    - title: RatePay - Invoice
+                      url: /docs/scos/dev/technology-partners/payment-partners/ratepay/ratepay-payment-methods/ratepay-invoice.html
+                      include_versions:
+                        - '202009.0'
+                        - '202108.0'
+                    - title: RatePay - Direct Debit
+                      url: /docs/scos/dev/technology-partners/payment-partners/ratepay/ratepay-payment-methods/ratepay-direct-.html
+                      include_versions:
+                        - '202009.0'
+                        - '202108.0'
+                - title: Technical details and HowTos
+                  nested:
+                    - title: RatePay - How to Disable Address Updates from the
+                        Backend Application
+                      url: /docs/scos/dev/technology-partners/payment-partners/ratepay/technical-details-and-howtos/ratepay-disable.html
+                      include_versions:
+                        - '202009.0'
+                        - '202108.0'
+                    - title: RatePay - Facade
+                      url: /docs/scos/dev/technology-partners/payment-partners/ratepay/technical-details-and-howtos/ratepay-facade.html
+                      include_versions:
+                        - '202009.0'
+                        - '202108.0'
+                    - title: RatePay - Payment Workflow
+                      url: /docs/scos/dev/technology-partners/payment-partners/ratepay/technical-details-and-howtos/ratepay-payment.html
+                      include_versions:
+                        - '202009.0'
+                        - '202108.0'
+                    - title: RatePay - State Machine Commands and Conditions
+                      url: /docs/scos/dev/technology-partners/payment-partners/ratepay/technical-details-and-howtos/ratepay-state-m.html
+                      include_versions:
+                        - '202009.0'
+                        - '202108.0'
+            - title: informa solutions
+              url: /docs/scos/dev/technology-partners/payment-partners/informa-solutio.html
+              include_versions:
+                - '201903.0'
+            - title: Adyen
+              nested:
+                - title: Adyen - Integration
+                  url: /docs/scos/dev/technology-partners/payment-partners/adyen/adyen-integrati.html
+                  include_versions:
+                    - '201811.0'
+                    - '201903.0'
+                    - '201907.0'
+                    - '202001.0'
+                    - '202005.0'
+                - title: Adyen - Provided Payment Methods
+                  url: /docs/scos/dev/technology-partners/payment-partners/adyen/adyen-provided-.html
+                  include_versions:
+                    - '201903.0'
+                - title: Adyen - Installation and Configuration
+                  url: /docs/scos/dev/technology-partners/payment-partners/adyen/adyen-configura.html
+                  include_versions:
+                    - '201903.0'
+                - title: Adyen - Filtering Payment Methods
+                  url: /docs/scos/dev/technology-partners/payment-partners/adyen/adyen-filter-pa.html
+                  include_versions:
+                    - '201903.0'
+                - title: Adyen
+                  url: /docs/scos/dev/technology-partners/payment-partners/adyen/adyen.html
+                - title: Payment Integration - Adyen
+                  url: /docs/scos/dev/technology-partners/payment-partners/adyen/adyen.html
+                  include_versions:
+                    - '201811.0'
+                - title: Adyen - Integration into a project
+                  url: /docs/scos/dev/technology-partners/payment-partners/adyen/adyen-integrati.html
+                  include_versions:
+                    - '202009.0'
+                    - '202108.0'
+            - title: Computop
+              nested:
+                - title: Computop - Sofort
+                  url: /docs/scos/dev/technology-partners/payment-partners/computop/computop-sofort.html
+                  include_versions:
+                    - '201811.0'
+                    - '201903.0'
+                    - '201907.0'
+                    - '202001.0'
+                    - '202005.0'
+                - title: Computop - Paydirekt
+                  url: /docs/scos/dev/technology-partners/payment-partners/computop/computop-paydir.html
+                  include_versions:
+                    - '201811.0'
+                    - '201903.0'
+                    - '201907.0'
+                    - '202001.0'
+                    - '202005.0'
+                - title: Computop - PayPal
+                  url: /docs/scos/dev/technology-partners/payment-partners/computop/computop-paypal.html
+                  include_versions:
+                    - '201811.0'
+                    - '201903.0'
+                    - '201907.0'
+                    - '202001.0'
+                    - '202005.0'
+                - title: Computop - CRIF
+                  url: /docs/scos/dev/technology-partners/payment-partners/computop/computop-crif.html
+                  include_versions:
+                    - '201811.0'
+                    - '201903.0'
+                    - '201907.0'
+                    - '202001.0'
+                    - '202005.0'
+                - title: Computop - iDeal
+                  url: /docs/scos/dev/technology-partners/payment-partners/computop/computop-ideal.html
+                  include_versions:
+                    - '201811.0'
+                    - '201903.0'
+                    - '201907.0'
+                    - '202001.0'
+                    - '202005.0'
+                - title: Computop - PayNow
+                  url: /docs/scos/dev/technology-partners/payment-partners/computop/computop-paynow.html
+                  include_versions:
+                    - '201811.0'
+                    - '201903.0'
+                    - '201907.0'
+                    - '202001.0'
+                    - '202005.0'
+                - title: Computop - API
+                  url: /docs/scos/dev/technology-partners/payment-partners/computop/computop-api-de.html
+                  include_versions:
+                    - '201811.0'
+                    - '201903.0'
+                    - '201907.0'
+                    - '202001.0'
+                    - '202005.0'
+                - title: Computop - OMS
+                  url: /docs/scos/dev/technology-partners/payment-partners/computop/computop-oms-de.html
+                  include_versions:
+                    - '201811.0'
+                    - '201903.0'
+                    - '201907.0'
+                    - '202001.0'
+                    - '202005.0'
+                - title: Computop - Credit Card
+                  url: /docs/scos/dev/technology-partners/payment-partners/computop/computop-credit.html
+                  include_versions:
+                    - '201811.0'
+                    - '201903.0'
+                    - '201907.0'
+                    - '202001.0'
+                    - '202005.0'
+                - title: Computop - Easy Credit
+                  url: /docs/scos/dev/technology-partners/payment-partners/computop/computop-easy-c.html
+                  include_versions:
+                    - '201811.0'
+                    - '201903.0'
+                    - '201907.0'
+                    - '202001.0'
+                    - '202005.0'
+                - title: Computop
+                  url: /docs/scos/dev/technology-partners/payment-partners/computop/computop.html
+                  include_versions:
+                    - '201903.0'
+                - title: Computop - Direct Debit
+                  url: /docs/scos/dev/technology-partners/payment-partners/computop/computop-direct.html
+                  include_versions:
+                    - '201811.0'
+                    - '201903.0'
+                    - '201907.0'
+                    - '202001.0'
+                    - '202005.0'
+                - title: Computop - Installation and configuration
+                  url: /docs/scos/dev/technology-partners/payment-partners/computop/computop-instal.html
+                  include_versions:
+                    - '202009.0'
+                    - '202108.0'
+                - title: Computop - Integration into a project
+                  url: /docs/scos/dev/technology-partners/payment-partners/computop/computop-integr.html
+                  include_versions:
+                    - '202009.0'
+                    - '202108.0'
+                - title: Technical details and HowTos
+                  nested:
+                    - title: Computop - API
+                      url: /docs/scos/dev/technology-partners/payment-partners/computop/technical-details-and-howtos/computop-api-de.html
+                      include_versions:
+                        - '202009.0'
+                        - '202108.0'
+                    - title: Computop - OMS
+                      url: /docs/scos/dev/technology-partners/payment-partners/computop/technical-details-and-howtos/computop-oms-de.html
+                      include_versions:
+                        - '202009.0'
+                        - '202108.0'
+                - title: Computop - Payment methods
+                  nested:
+                    - title: Computop - Sofort
+                      url: /docs/scos/dev/technology-partners/payment-partners/computop/computop-payment-methods/computop-sofort.html
+                      include_versions:
+                        - '202009.0'
+                        - '202108.0'
+                    - title: Computop - Paydirekt
+                      url: /docs/scos/dev/technology-partners/payment-partners/computop/computop-payment-methods/computop-paydir.html
+                      include_versions:
+                        - '202009.0'
+                        - '202108.0'
+                    - title: Computop - PayPal
+                      url: /docs/scos/dev/technology-partners/payment-partners/computop/computop-payment-methods/computop-paypal.html
+                      include_versions:
+                        - '202009.0'
+                        - '202108.0'
+                    - title: Computop - CRIF
+                      url: /docs/scos/dev/technology-partners/payment-partners/computop/computop-payment-methods/computop-crif.html
+                      include_versions:
+                        - '202009.0'
+                        - '202108.0'
+                    - title: Computop - iDeal
+                      url: /docs/scos/dev/technology-partners/payment-partners/computop/computop-payment-methods/computop-ideal.html
+                      include_versions:
+                        - '202009.0'
+                        - '202108.0'
+                    - title: Computop - PayNow
+                      url: /docs/scos/dev/technology-partners/payment-partners/computop/computop-payment-methods/computop-paynow.html
+                      include_versions:
+                        - '202009.0'
+                        - '202108.0'
+                    - title: Computop - Credit Card
+                      url: /docs/scos/dev/technology-partners/payment-partners/computop/computop-payment-methods/computop-credit.html
+                      include_versions:
+                        - '202009.0'
+                        - '202108.0'
+                    - title: Computop - Easy Credit
+                      url: /docs/scos/dev/technology-partners/payment-partners/computop/computop-payment-methods/computop-easy-c.html
+                      include_versions:
+                        - '202009.0'
+                        - '202108.0'
+                    - title: Computop - Direct Debit
+                      url: /docs/scos/dev/technology-partners/payment-partners/computop/computop-payment-methods/computop-direct.html
+                      include_versions:
+                        - '202009.0'
+                        - '202108.0'
+            - title: CrefoPay
+              nested:
+                - title: CrefoPay - Integration
+                  url: /docs/scos/dev/technology-partners/payment-partners/crefopay/crefopay-integr.html
+                  include_versions:
+                    - '201811.0'
+                    - '201903.0'
+                    - '201907.0'
+                    - '202001.0'
+                    - '202005.0'
+                - title: CrefoPay - Installation and Configuration
+                  url: /docs/scos/dev/technology-partners/payment-partners/crefopay/crefopay-config.html
+                  include_versions:
+                    - '201903.0'
+                - title: CrefoPay - Provided Payment Methods
+                  url: /docs/scos/dev/technology-partners/payment-partners/crefopay/crefopay-provid.html
+                  include_versions:
+                    - '201903.0'
+                - title: CrefoPay - Technical details and HowTos
+                  nested:
+                    - title: CrefoPay - Business to Business Model
+                      url: /docs/scos/dev/technology-partners/payment-partners/crefopay/crefopay-technical-details-and-howtos/crefopay-busine.html
+                      include_versions:
+                        - '201903.0'
+                    - title: CrefoPay - Callback
+                      url: /docs/scos/dev/technology-partners/payment-partners/crefopay/crefopay-technical-details-and-howtos/crefopay-callba.html
+                      include_versions:
+                        - '201903.0'
+                    - title: CrefoPay - Capture and Refund Processes
+                      url: /docs/scos/dev/technology-partners/payment-partners/crefopay/crefopay-technical-details-and-howtos/crefopay-captur.html
+                      include_versions:
+                        - '201903.0'
+                    - title: CrefoPay - Notifications
+                      url: /docs/scos/dev/technology-partners/payment-partners/crefopay/crefopay-technical-details-and-howtos/crefopay-notifi.html
+                      include_versions:
+                        - '201903.0'
+                - title: CrefoPay
+                  url: /docs/scos/dev/technology-partners/payment-partners/crefopay/crefopay.html
+                  include_versions:
+                    - '201903.0'
+                - title: CrefoPay - Integration into a project
+                  url: /docs/scos/dev/technology-partners/payment-partners/crefopay/crefopay-integr.html
+                  include_versions:
+                    - '202009.0'
+                    - '202108.0'
+            - title: Billie
+              url: /docs/scos/dev/technology-partners/payment-partners/billie.html
+              include_versions:
+                - '201903.0'
+            - title: AfterPay
+              nested:
+                - title: AfterPay
+                  url: /docs/scos/dev/technology-partners/payment-partners/afterpay/afterpay.html
+                  include_versions:
+                    - '201903.0'
+                - title: Afterpay - Installation and Configuration
+                  url: /docs/scos/dev/technology-partners/payment-partners/afterpay/afterpay-instal.html
+                  include_versions:
+                    - '201903.0'
+            - title: Powerpay
+              url: /docs/scos/dev/technology-partners/payment-partners/powerpay.html
+              include_versions:
+                - '201903.0'
+            - title: Ratenkauf by Easycredit
+              nested:
+                - title: Ratenkauf by Easycredit - Installation and Configuration
+                  url: /docs/scos/dev/technology-partners/payment-partners/ratenkauf-by-easycredit/ratenkauf-by-ea.html
+                  include_versions:
+                    - '201811.0'
+                    - '201903.0'
+                    - '201907.0'
+                    - '202001.0'
+                    - '202005.0'
+                - title: Ratenkauf by Easycredit - Integration into a project
+                  url: /docs/scos/dev/technology-partners/payment-partners/ratenkauf-by-easycredit/ratenkauf-integ.html
+                  include_versions:
+                    - '202009.0'
+                    - '202108.0'
+                - title: Ratenkauf by Easycredit - Installation and configuration
+                  url: /docs/scos/dev/technology-partners/payment-partners/ratenkauf-by-easycredit/ratenkauf-by-ea.html
+                  include_versions:
+                    - '202009.0'
+                    - '202108.0'
+            - title: Payolution
+              nested:
+                - title: Payolution - Workflow
+                  url: /docs/scos/dev/technology-partners/payment-partners/payolution/payolution-work.html
+                  include_versions:
+                    - '201811.0'
+                    - '201903.0'
+                    - '201907.0'
+                    - '202001.0'
+                    - '202005.0'
+                - title: Payolution
+                  url: /docs/scos/dev/technology-partners/payment-partners/payolution/payolution.html
+                  include_versions:
+                    - '201903.0'
+                - title: Payolution - Provided Payment Methods
+                  nested:
+                    - title: Payolution - Invoice Payment
+                      url: /docs/scos/dev/technology-partners/payment-partners/payolution/payolution-provided-payment-methods/payolution-invo.html
+                      include_versions:
+                        - '202001.0'
+                        - '202005.0'
+                    - title: Payolution - Installment Payment
+                      url: /docs/scos/dev/technology-partners/payment-partners/payolution/payolution-provided-payment-methods/payolution-inst.html
+                      include_versions:
+                        - '202001.0'
+                        - '202005.0'
+                - title: Payolution - Installation and Configuration
+                  url: /docs/scos/dev/technology-partners/payment-partners/payolution/payolution-conf.html
+                  include_versions:
+                    - '202001.0'
+                    - '202005.0'
+                    - '202009.0'
+                    - '202108.0'
+                - title: Payolution - Performing Requests
+                  url: /docs/scos/dev/technology-partners/payment-partners/payolution/payolution-requ.html
+                  include_versions:
+                    - '201811.0'
+                    - '201903.0'
+                    - '201907.0'
+                    - '202001.0'
+                    - '202005.0'
+                - title: Payolution - Invoice Payment
+                  url: /docs/scos/dev/technology-partners/payment-partners/payolution/payolution-invo.html
+                  include_versions:
+                    - '201811.0'
+                    - '201903.0'
+                    - '201907.0'
+                - title: Payolution - Installment Payment
+                  url: /docs/scos/dev/technology-partners/payment-partners/payolution/payolution-inst.html
+                  include_versions:
+                    - '201811.0'
+                    - '201903.0'
+                    - '201907.0'
+                - title: Payolution - Configuration
+                  url: /docs/scos/dev/technology-partners/payment-partners/payolution/payolution-conf.html
+                  include_versions:
+                    - '201811.0'
+                    - '201903.0'
+                    - '201907.0'
+                - title: Payolution - Integration into a project
+                  url: /docs/scos/dev/technology-partners/payment-partners/payolution/payolution-inte.html
+                  include_versions:
+                    - '202009.0'
+                    - '202108.0'
+                - title: Technical details and HowTos
+                  nested:
+                    - title: Payolution - Workflow
+                      url: /docs/scos/dev/technology-partners/payment-partners/payolution/technical-details-and-howtos/payolution-work.html
+                      include_versions:
+                        - '202009.0'
+                        - '202108.0'
+                    - title: Payolution - Performing Requests
+                      url: /docs/scos/dev/technology-partners/payment-partners/payolution/technical-details-and-howtos/payolution-requ.html
+                      include_versions:
+                        - '202009.0'
+                        - '202108.0'
+                - title: Payolution - Payment methods
+                  nested:
+                    - title: Payolution - Invoice Payment
+                      url: /docs/scos/dev/technology-partners/payment-partners/payolution/payolution-payment-methods/payolution-invo.html
+                      include_versions:
+                        - '202009.0'
+                        - '202108.0'
+                    - title: Payolution - Installment Payment
+                      url: /docs/scos/dev/technology-partners/payment-partners/payolution/payolution-payment-methods/payolution-inst.html
+                      include_versions:
+                        - '202009.0'
+                        - '202108.0'
+            - title: Arvato
+              nested:
+                - title: Arvato - Risk Check
+                  url: /docs/scos/dev/technology-partners/payment-partners/arvato/arvato-risk-che.html
+                  include_versions:
+                    - '202001.0'
+                    - '202005.0'
+                    - '202009.0'
+                    - '202108.0'
+                - title: Arvato
+                  url: /docs/scos/dev/technology-partners/payment-partners/arvato/arvato.html
+                  include_versions:
+                    - '201903.0'
+                - title: v.1.0
+                  nested:
+                    - title: Arvato - Risk Check 1.0
+                      url: /docs/scos/dev/technology-partners/payment-partners/arvato/v.1.0/arvato-risk-che.html
+                      include_versions:
+                        - '201811.0'
+                        - '201903.0'
+                        - '201907.0'
+                        - '202001.0'
+                        - '202005.0'
+                    - title: Arvato - Risk Solution Services Integration 1.0
+                      url: /docs/scos/dev/technology-partners/payment-partners/arvato/v.1.0/arvato-1-0.html
+                      include_versions:
+                        - '201811.0'
+                        - '201903.0'
+                        - '201907.0'
+                        - '202001.0'
+                        - '202005.0'
+                - title: Arvato - Risk Solution Services Integration
+                  url: /docs/scos/dev/technology-partners/payment-partners/arvato/arvato-2-0.html
+                  include_versions:
+                    - '202001.0'
+                    - '202005.0'
+                - title: Arvato - Store Order
+                  url: /docs/scos/dev/technology-partners/payment-partners/arvato/arvato-store-or.html
+                  include_versions:
+                    - '202001.0'
+                    - '202005.0'
+                    - '202009.0'
+                    - '202108.0'
+                - title: v.2.0
+                  nested:
+                    - title: Arvato - Risk Check 2.0
+                      url: /docs/scos/dev/technology-partners/payment-partners/arvato/v.2.0/arvato-risk-che.html
+                      include_versions:
+                        - '201811.0'
+                        - '201903.0'
+                        - '201907.0'
+                    - title: Arvato - Risk Solution Services Integration 2.0
+                      url: /docs/scos/dev/technology-partners/payment-partners/arvato/v.2.0/arvato-2-0.html
+                      include_versions:
+                        - '201811.0'
+                        - '201903.0'
+                        - '201907.0'
+                    - title: Arvato - Store Order 2.0
+                      url: /docs/scos/dev/technology-partners/payment-partners/arvato/v.2.0/arvato-store-or.html
+                      include_versions:
+                        - '201811.0'
+                        - '201903.0'
+                        - '201907.0'
+                - title: Arvato - Installation and Configuration
+                  url: /docs/scos/dev/technology-partners/payment-partners/arvato/arvato-installa.html
+                  include_versions:
+                    - '202009.0'
+                    - '202108.0'
+        - title: Content Management
+          nested:
+            - title: E-Spirit
+              url: /docs/scos/dev/technology-partners/content-management/e-spirit.html
+              include_versions:
+                - '201903.0'
+            - title: Magnolia
+              url: /docs/scos/dev/technology-partners/content-management/magnolia-cms.html
+              include_versions:
+                - '201903.0'
+            - title: Censhare
+              url: /docs/scos/dev/technology-partners/content-management/censhare.html
+              include_versions:
+                - '201903.0'
+            - title: Styla
+              url: /docs/scos/dev/technology-partners/content-management/styla.html
+              include_versions:
+                - '201903.0'
+            - title: CoreMedia
+              nested:
+                - title: Coremedia
+                  url: /docs/scos/dev/technology-partners/content-management/coremedia/coremedia.html
+                  include_versions:
+                    - '202001.0'
+                    - '202005.0'
+                    - '202009.0'
+                    - '202108.0'
+                - title: Coremedia with Templates & Slots
+                  url: /docs/scos/dev/technology-partners/content-management/coremedia/coremedia-with-.html
+                  include_versions:
+                    - '202001.0'
+                    - '202005.0'
+            - title: Coremedia
+              url: /docs/scos/dev/technology-partners/content-management/coremedia.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+                - '201907.0'
+        - title: Product Information (PIMERP)
+          nested:
+            - title: Contentserv
+              url: /docs/scos/dev/technology-partners/product-information-pimerp/contentserv.html
+              include_versions:
+                - '201903.0'
+            - title: Censhare PIM
+              url: /docs/scos/dev/technology-partners/product-information-pimerp/censhare-pim.html
+              include_versions:
+                - '202001.0'
+                - '202005.0'
+                - '202009.0'
+                - '202108.0'
+            - title: Akeneo
+              nested:
+                - title: Akeneo - Installation and Configuration
+                  url: /docs/scos/dev/technology-partners/product-information-pimerp/akeneo/akeneo-installa.html
+                  include_versions:
+                    - '201903.0'
+                - title: Akeneo
+                  url: /docs/scos/dev/technology-partners/product-information-pimerp/akeneo/akeneo.html
+                  include_versions:
+                    - '201903.0'
+                - title: Akeneo - Console commands
+                  url: /docs/scos/dev/technology-partners/product-information-pimerp/akeneo/akeneo-console-.html
+                  include_versions:
+                    - '202009.0'
+                    - '202108.0'
+            - title: Censhare
+              url: /docs/scos/dev/technology-partners/product-information-pimerp/censhare-1.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+                - '201907.0'
+            - title: Xentral
+              url: /docs/scos/dev/technology-partners/product-information-pimerp/xentral.html
+        - title: Shipment
+          nested:
+            - title: Paqato
+              url: /docs/scos/dev/technology-partners/shipment/paqato.html
+              include_versions:
+                - '201903.0'
+            - title: Seven Senders
+              url: /docs/scos/dev/technology-partners/shipment/sevensenders.html
+              include_versions:
+                - '201903.0'
+            - title: Paazl
+              url: /docs/scos/dev/technology-partners/shipment/paazl.html
+              include_versions:
+                - '201903.0'
+        - title: Technology Partner Integration
+          url: /docs/scos/dev/technology-partners/technology-part.html
+          include_versions:
+            - '201811.0'
+            - '201903.0'
+            - '201907.0'
+            - '202001.0'
+            - '202005.0'
+        - title: Taxes
+          nested:
+            - title: Avalara Tax + Shipment feature integration
+              url: /docs/scos/dev/technology-partners/taxes/avalara-tax-shi.html
+              include_versions:
+                - '202108.0'
+            - title: Avalara Tax + Product Options feature integration
+              url: /docs/scos/dev/technology-partners/taxes/avalara-tax-pro.html
+              include_versions:
+                - '202108.0'
+            - title: Avalara Tax integration
+              url: /docs/scos/dev/technology-partners/taxes/avalara-tax-int.html
+              include_versions:
+                - '202108.0'
+        - title: Technology partner integration
+          url: /docs/scos/dev/technology-partners/technology-part.html
+          include_versions:
+            - '202009.0'
+            - '202108.0'

--- a/_data/sidebars/scos_user_sidebar.yml
+++ b/_data/sidebars/scos_user_sidebar.yml
@@ -1,0 +1,3312 @@
+title: SCOS Developer Guides
+entries:
+  - product: SCOS
+    nested:
+    - title: User guides
+      nested:
+        - title: About User Guides
+          url: /docs/scos/dev/user-guides/about-user-guid.html
+          include_versions:
+            - '201811.0'
+            - '201903.0'
+            - '201907.0'
+            - '202001.0'
+            - '202005.0'
+        - title: Back Office user guide
+          nested:
+            - title: Customers
+              nested:
+                - title: 'Customers, Customer Access, Customer Groups'
+                  nested:
+                    - title: Managing Customer Addresses
+                      url: /docs/scos/dev/user-guides/back-office-user-guide/customers/customers-customer-access-customer-groups/managing-custom.html
+                      include_versions:
+                        - '201811.0'
+                        - '201903.0'
+                        - '201907.0'
+                        - '202001.0'
+                - title: References
+                  nested:
+                    - title: Customers- Reference Information
+                      url: /docs/scos/dev/user-guides/back-office-user-guide/customers/references/customers-refer.html
+                      include_versions:
+                        - '201811.0'
+                        - '201903.0'
+                        - '201907.0'
+                        - '202001.0'
+                - title: Customers
+                  url: /docs/scos/dev/user-guides/back-office-user-guide/customers/customers.html
+                  include_versions:
+                    - '201811.0'
+                    - '201903.0'
+                    - '201907.0'
+                    - '202001.0'
+            - title: General Back Office Overview
+              url: /docs/scos/dev/user-guides/back-office-user-guide/general-back-of.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+                - '201907.0'
+                - '202001.0'
+                - '202005.0'
+            - title: Products
+              nested:
+                - title: Product Barcode
+                  nested:
+                    - title: Product Barcodes
+                      url: /docs/scos/dev/user-guides/back-office-user-guide/products/product-barcode/product-barcode.html
+                      include_versions:
+                        - '201811.0'
+                        - '201903.0'
+                        - '201907.0'
+                        - '202001.0'
+                - title: Product reviews
+                  nested:
+                    - title: Product Reviews
+                      url: /docs/scos/dev/user-guides/back-office-user-guide/products/product-reviews/product-reviews.html
+                      include_versions:
+                        - '201811.0'
+                        - '201903.0'
+                        - '201907.0'
+                        - '202001.0'
+                    - title: Managing Product Reviews
+                      url: /docs/scos/dev/user-guides/back-office-user-guide/products/product-reviews/managing-produc.html
+                      include_versions:
+                        - '201811.0'
+                        - '201903.0'
+                        - '201907.0'
+                        - '202001.0'
+                - title: Products
+                  url: /docs/scos/dev/user-guides/back-office-user-guide/products/products.html
+                  include_versions:
+                    - '201811.0'
+                    - '201903.0'
+                    - '201907.0'
+                    - '202001.0'
+                - title: Configurable bundle templates
+                  nested:
+                    - title: References
+                      nested:
+                        - title: Configurable Bundle Templates- Reference Information
+                          url: /docs/scos/dev/user-guides/back-office-user-guide/products/configurable-bundle-templates/references/configurable-bu.html
+                          include_versions:
+                            - '202001.0'
+                    - title: Managing Configurable Bundle Templates
+                      url: /docs/scos/dev/user-guides/back-office-user-guide/products/configurable-bundle-templates/managing-config.html
+                      include_versions:
+                        - '202001.0'
+                    - title: Creating Configurable Bundle Templates
+                      url: /docs/scos/dev/user-guides/back-office-user-guide/products/configurable-bundle-templates/creating-config.html
+                      include_versions:
+                        - '202001.0'
+                    - title: Configurable Bundle Templates
+                      url: /docs/scos/dev/user-guides/back-office-user-guide/products/configurable-bundle-templates/configurable-bu.html
+                      include_versions:
+                        - '202001.0'
+                - title: Attributes
+                  nested:
+                    - title: Managing Attributes
+                      url: /docs/scos/dev/user-guides/back-office-user-guide/products/attributes/managing-attrib.html
+                      include_versions:
+                        - '201811.0'
+                        - '201903.0'
+                        - '201907.0'
+                        - '202001.0'
+                    - title: References
+                      nested:
+                        - title: Attributes- Reference Information
+                          url: /docs/scos/dev/user-guides/back-office-user-guide/products/attributes/references/attributes-refe.html
+                          include_versions:
+                            - '201811.0'
+                            - '201903.0'
+                            - '201907.0'
+                            - '202001.0'
+                    - title: Creating a Product Attribute
+                      url: /docs/scos/dev/user-guides/back-office-user-guide/products/attributes/creating-a-prod.html
+                      include_versions:
+                        - '201811.0'
+                        - '201903.0'
+                        - '201907.0'
+                        - '202001.0'
+                    - title: Attributes
+                      url: /docs/scos/dev/user-guides/back-office-user-guide/products/attributes/attributes.html
+                      include_versions:
+                        - '201811.0'
+                        - '201903.0'
+                        - '201907.0'
+                        - '202001.0'
+                - title: Creating Service Offerings
+                  url: /docs/scos/dev/user-guides/back-office-user-guide/products/creating-servic.html
+                  include_versions:
+                    - '202001.0'
+                - title: Availability
+                  nested:
+                    - title: References
+                      nested:
+                        - title: Availability- Reference Information
+                          url: /docs/scos/dev/user-guides/back-office-user-guide/products/availability/references/availability-re.html
+                          include_versions:
+                            - '201811.0'
+                            - '201903.0'
+                            - '201907.0'
+                            - '202001.0'
+                    - title: Managing Products Availability
+                      url: /docs/scos/dev/user-guides/back-office-user-guide/products/availability/managing-produc.html
+                      include_versions:
+                        - '201811.0'
+                        - '201903.0'
+                        - '201907.0'
+                        - '202001.0'
+                - title: Product relations
+                  nested:
+                    - title: References
+                      nested:
+                        - title: Product Relations- Reference Information
+                          url: /docs/scos/dev/user-guides/back-office-user-guide/products/product-relations/references/product-relatio.html
+                          include_versions:
+                            - '201811.0'
+                            - '201903.0'
+                            - '201907.0'
+                            - '202001.0'
+                    - title: Creating a Product Relation
+                      url: /docs/scos/dev/user-guides/back-office-user-guide/products/product-relations/creating-a-prod.html
+                      include_versions:
+                        - '201811.0'
+                        - '201903.0'
+                        - '201907.0'
+                        - '202001.0'
+                    - title: Managing Product Relations
+                      url: /docs/scos/dev/user-guides/back-office-user-guide/products/product-relations/managing-produc.html
+                      include_versions:
+                        - '201811.0'
+                        - '201903.0'
+                        - '201907.0'
+                        - '202001.0'
+                    - title: Product Relations
+                      url: /docs/scos/dev/user-guides/back-office-user-guide/products/product-relations/product-relatio.html
+                      include_versions:
+                        - '201811.0'
+                        - '201903.0'
+                        - '201907.0'
+                        - '202001.0'
+                - title: Product lists
+                  nested:
+                    - title: References
+                      nested:
+                        - title: Product Lists- Reference Information
+                          url: /docs/scos/dev/user-guides/back-office-user-guide/products/product-lists/references/product-lists-r.html
+                          include_versions:
+                            - '201811.0'
+                            - '201903.0'
+                            - '201907.0'
+                            - '202001.0'
+                    - title: Creating a Product List
+                      url: /docs/scos/dev/user-guides/back-office-user-guide/products/product-lists/creating-a-prod.html
+                      include_versions:
+                        - '201811.0'
+                        - '201903.0'
+                        - '201907.0'
+                        - '202001.0'
+                    - title: Managing Product Lists
+                      url: /docs/scos/dev/user-guides/back-office-user-guide/products/product-lists/managing-produc.html
+                      include_versions:
+                        - '201811.0'
+                        - '201903.0'
+                        - '201907.0'
+                        - '202001.0'
+                    - title: Product Lists
+                      url: /docs/scos/dev/user-guides/back-office-user-guide/products/product-lists/product-lists.html
+                      include_versions:
+                        - '201811.0'
+                        - '201903.0'
+                        - '201907.0'
+                        - '202001.0'
+                - title: Product options
+                  nested:
+                    - title: References
+                      nested:
+                        - title: Product Options- Reference Information
+                          url: /docs/scos/dev/user-guides/back-office-user-guide/products/product-options/references/product-options.html
+                          include_versions:
+                            - '201811.0'
+                            - '201903.0'
+                            - '201907.0'
+                            - '202001.0'
+                    - title: Product Options
+                      url: /docs/scos/dev/user-guides/back-office-user-guide/products/product-options/product-options.html
+                      include_versions:
+                        - '201811.0'
+                        - '201903.0'
+                        - '201907.0'
+                        - '202001.0'
+                    - title: Creating a Product Option
+                      url: /docs/scos/dev/user-guides/back-office-user-guide/products/product-options/creating-a-prod.html
+                      include_versions:
+                        - '201811.0'
+                        - '201903.0'
+                        - '201907.0'
+                        - '202001.0'
+                    - title: Managing Product Options
+                      url: /docs/scos/dev/user-guides/back-office-user-guide/products/product-options/managing-produc.html
+                      include_versions:
+                        - '201811.0'
+                        - '201903.0'
+                        - '201907.0'
+                        - '202001.0'
+                - title: Product labels
+                  nested:
+                    - title: Product Labels
+                      url: /docs/scos/dev/user-guides/back-office-user-guide/products/product-labels/product-labels.html
+                      include_versions:
+                        - '201811.0'
+                        - '201903.0'
+                        - '201907.0'
+                        - '202001.0'
+                    - title: References
+                      nested:
+                        - title: Product Labels- Reference Information
+                          url: /docs/scos/dev/user-guides/back-office-user-guide/products/product-labels/references/product-labels-.html
+                          include_versions:
+                            - '201811.0'
+                            - '201903.0'
+                            - '201907.0'
+                            - '202001.0'
+                    - title: Creating a Product Label
+                      url: /docs/scos/dev/user-guides/back-office-user-guide/products/product-labels/creating-a-prod.html
+                      include_versions:
+                        - '201811.0'
+                        - '201903.0'
+                        - '201907.0'
+                        - '202001.0'
+                    - title: Managing Product Labels
+                      url: /docs/scos/dev/user-guides/back-office-user-guide/products/product-labels/managing-produc.html
+                      include_versions:
+                        - '201811.0'
+                        - '201903.0'
+                        - '201907.0'
+                        - '202001.0'
+                    - title: Prioritizing Labels
+                      url: /docs/scos/dev/user-guides/back-office-user-guide/products/product-labels/prioritizing-la.html
+                      include_versions:
+                        - '201811.0'
+                        - '201903.0'
+                        - '201907.0'
+                        - '202001.0'
+                - title: Product sets
+                  nested:
+                    - title: References
+                      nested:
+                        - title: Product Sets- Reference Information
+                          url: /docs/scos/dev/user-guides/back-office-user-guide/products/product-sets/references/product-sets-re.html
+                          include_versions:
+                            - '201811.0'
+                            - '201903.0'
+                            - '201907.0'
+                            - '202001.0'
+                    - title: Creating a Product Set
+                      url: /docs/scos/dev/user-guides/back-office-user-guide/products/product-sets/creating-a-prod.html
+                      include_versions:
+                        - '201811.0'
+                        - '201903.0'
+                        - '201907.0'
+                        - '202001.0'
+                    - title: Product Sets
+                      url: /docs/scos/dev/user-guides/back-office-user-guide/products/product-sets/product-sets.html
+                      include_versions:
+                        - '201811.0'
+                        - '201903.0'
+                        - '201907.0'
+                        - '202001.0'
+                    - title: Managing Product Sets
+                      url: /docs/scos/dev/user-guides/back-office-user-guide/products/product-sets/managing-produc.html
+                      include_versions:
+                        - '201811.0'
+                        - '201903.0'
+                        - '201907.0'
+                        - '202001.0'
+            - title: About the Back Offfice User Guide
+              url: /docs/scos/dev/user-guides/back-office-user-guide/about-the-back-.html
+              include_versions:
+                - '202001.0'
+                - '202005.0'
+            - title: Thresholds
+              nested:
+                - title: Threshold
+                  url: /docs/scos/dev/user-guides/back-office-user-guide/thresholds/threshold.html
+                  include_versions:
+                    - '201903.0'
+                    - '201907.0'
+                    - '202001.0'
+                - title: References
+                  nested:
+                    - title: Threshold- Reference Information
+                      url: /docs/scos/dev/user-guides/back-office-user-guide/thresholds/references/threshold-refer.html
+                      include_versions:
+                        - '201903.0'
+                        - '201907.0'
+                        - '202001.0'
+                - title: Threshold Settings
+                  nested:
+                    - title: Managing Threshold Settings
+                      url: /docs/scos/dev/user-guides/back-office-user-guide/thresholds/threshold-settings/managing-thresh.html
+                      include_versions:
+                        - '201903.0'
+                        - '201907.0'
+                        - '202001.0'
+                - title: Global Threshold
+                  nested:
+                    - title: Managing Global Threshold
+                      url: /docs/scos/dev/user-guides/back-office-user-guide/thresholds/global-threshold/managing-global.html
+                      include_versions:
+                        - '201903.0'
+                        - '201907.0'
+                        - '202001.0'
+                - title: Merchant Relationships
+                  nested:
+                    - title: Managing Merchant Relationships Thresholds
+                      url: /docs/scos/dev/user-guides/back-office-user-guide/thresholds/merchant-relationships/managing-mercha.html
+                      include_versions:
+                        - '201903.0'
+                        - '201907.0'
+                        - '202001.0'
+            - title: Category
+              nested:
+                - title: Creating Categories
+                  url: /docs/scos/dev/user-guides/back-office-user-guide/category/creating-catego.html
+                  include_versions:
+                    - '201811.0'
+                    - '201903.0'
+                    - '201907.0'
+                    - '202001.0'
+                - title: Managing Categories
+                  url: /docs/scos/dev/user-guides/back-office-user-guide/category/managing-catego.html
+                  include_versions:
+                    - '201811.0'
+                    - '201903.0'
+                    - '201907.0'
+                    - '202001.0'
+                - title: References
+                  nested:
+                    - title: Category- Reference Information
+                      url: /docs/scos/dev/user-guides/back-office-user-guide/category/references/category-refere.html
+                      include_versions:
+                        - '201811.0'
+                        - '201903.0'
+                        - '201907.0'
+                        - '202001.0'
+                - title: Category
+                  url: /docs/scos/dev/user-guides/back-office-user-guide/category/category.html
+                  include_versions:
+                    - '201811.0'
+                    - '201903.0'
+                    - '201907.0'
+                    - '202001.0'
+                - title: Assigning Products to Categories
+                  url: /docs/scos/dev/user-guides/back-office-user-guide/category/assigning-produ.html
+                  include_versions:
+                    - '201811.0'
+                    - '201903.0'
+                    - '201907.0'
+                    - '202001.0'
+            - title: Sales
+              nested:
+                - title: Sales
+                  url: /docs/scos/dev/user-guides/back-office-user-guide/sales/sales-managemen.html
+                  include_versions:
+                    - '201811.0'
+                    - '201903.0'
+                    - '201907.0'
+                    - '202001.0'
+                    - '202005.0'
+                - title: Reclamations
+                  nested:
+                    - title: Managing Reclamations
+                      url: /docs/scos/dev/user-guides/back-office-user-guide/sales/reclamations/managing-reclam.html
+                      include_versions:
+                        - '201903.0'
+                        - '201907.0'
+                        - '202001.0'
+                        - '202005.0'
+                    - title: References
+                      nested:
+                        - title: Reclamations- Reference Information
+                          url: /docs/scos/dev/user-guides/back-office-user-guide/sales/reclamations/references/reclamations-re.html
+                          include_versions:
+                            - '201903.0'
+                            - '201907.0'
+                            - '202001.0'
+                            - '202005.0'
+                        - title: Reference information- reclamations
+                          url: /docs/scos/dev/user-guides/back-office-user-guide/sales/reclamations/references/reclamations-re.html
+                          include_versions:
+                            - '202009.0'
+                            - '202108.0'
+                    - title: Managing reclamations
+                      url: /docs/scos/dev/user-guides/back-office-user-guide/sales/reclamations/managing-reclam.html
+                      include_versions:
+                        - '202009.0'
+                        - '202108.0'
+                - title: Order matrix
+                  nested:
+                    - title: Order Matrix- Reference Information
+                      url: /docs/scos/dev/user-guides/back-office-user-guide/sales/order-matrix/order-matrix-re.html
+                      include_versions:
+                        - '201811.0'
+                        - '201903.0'
+                        - '201907.0'
+                        - '202001.0'
+                        - '202005.0'
+                    - title: Reference information- order matrix
+                      url: /docs/scos/dev/user-guides/back-office-user-guide/sales/order-matrix/order-matrix-re.html
+                      include_versions:
+                        - '202009.0'
+                        - '202108.0'
+                - title: Refunds
+                  nested:
+                    - title: Refunds- Reference Information
+                      url: /docs/scos/dev/user-guides/back-office-user-guide/sales/refunds/refunds-referen.html
+                      include_versions:
+                        - '201811.0'
+                        - '201903.0'
+                        - '201907.0'
+                        - '202001.0'
+                        - '202005.0'
+                    - title: Reference information- refunds
+                      url: /docs/scos/dev/user-guides/back-office-user-guide/sales/refunds/refunds-referen.html
+                      include_versions:
+                        - '202009.0'
+                        - '202108.0'
+                - title: Orders
+                  nested:
+                    - title: Managing Order Shipments
+                      url: /docs/scos/dev/user-guides/back-office-user-guide/sales/orders/managing-order-.html
+                      include_versions:
+                        - '202001.0'
+                        - '202005.0'
+                    - title: References
+                      nested:
+                        - title: Orders- Reference Information
+                          url: /docs/scos/dev/user-guides/back-office-user-guide/sales/orders/references/orders-referenc.html
+                          include_versions:
+                            - '201811.0'
+                            - '201903.0'
+                            - '201907.0'
+                            - '202001.0'
+                            - '202005.0'
+                        - title: Reference information- orders
+                          url: /docs/scos/dev/user-guides/back-office-user-guide/sales/orders/references/orders-referenc.html
+                          include_versions:
+                            - '202009.0'
+                            - '202108.0'
+                    - title: Managing Orders
+                      url: /docs/scos/dev/user-guides/back-office-user-guide/sales/orders/managing-orders.html
+                      include_versions:
+                        - '201811.0'
+                        - '201903.0'
+                        - '201907.0'
+                        - '202001.0'
+                        - '202005.0'
+                    - title: Managing order shipments
+                      url: /docs/scos/dev/user-guides/back-office-user-guide/sales/orders/managing-order-.html
+                      include_versions:
+                        - '202009.0'
+                        - '202108.0'
+                    - title: Managing orders
+                      url: /docs/scos/dev/user-guides/back-office-user-guide/sales/orders/managing-orders.html
+                      include_versions:
+                        - '202009.0'
+                        - '202108.0'
+                - title: Returns
+                  nested:
+                    - title: Managing Returns
+                      url: /docs/scos/dev/user-guides/back-office-user-guide/sales/returns/managing-return.html
+                      include_versions:
+                        - '202005.0'
+                    - title: References
+                      nested:
+                        - title: Return Item States- Reference Information
+                          url: /docs/scos/dev/user-guides/back-office-user-guide/sales/returns/references/return-item-sta.html
+                          include_versions:
+                            - '202005.0'
+                        - title: Returns- Reference Information
+                          url: /docs/scos/dev/user-guides/back-office-user-guide/sales/returns/references/returns-referen.html
+                          include_versions:
+                            - '202005.0'
+                        - title: Reference information- return item states
+                          url: /docs/scos/dev/user-guides/back-office-user-guide/sales/returns/references/return-item-sta.html
+                          include_versions:
+                            - '202009.0'
+                            - '202108.0'
+                        - title: Reference information- returns
+                          url: /docs/scos/dev/user-guides/back-office-user-guide/sales/returns/references/returns-referen.html
+                          include_versions:
+                            - '202009.0'
+                            - '202108.0'
+                    - title: Managing returns
+                      url: /docs/scos/dev/user-guides/back-office-user-guide/sales/returns/managing-return.html
+                      include_versions:
+                        - '202009.0'
+                        - '202108.0'
+            - title: Punch out
+              nested:
+                - title: References
+                  nested:
+                    - title: Punch Out- Reference Information
+                      url: /docs/scos/dev/user-guides/back-office-user-guide/punch-out/references/punch-out-refer.html
+                      include_versions:
+                        - '201907.0'
+                        - '202001.0'
+                        - '202005.0'
+                    - title: Reference information- Punchout
+                      url: /docs/scos/dev/user-guides/back-office-user-guide/punch-out/references/punch-out-refer.html
+                      include_versions:
+                        - '202009.0'
+                        - '202108.0'
+                - title: Managing Transactions Log
+                  url: /docs/scos/dev/user-guides/back-office-user-guide/punch-out/managing-transa.html
+                  include_versions:
+                    - '201907.0'
+                    - '202001.0'
+                    - '202005.0'
+                - title: Managing Punch Out Connections
+                  url: /docs/scos/dev/user-guides/back-office-user-guide/punch-out/managing-puncho.html
+                  include_versions:
+                    - '201907.0'
+                    - '202001.0'
+                    - '202005.0'
+                - title: Punch Out
+                  url: /docs/scos/dev/user-guides/back-office-user-guide/punch-out/punch-out.html
+                  include_versions:
+                    - '201907.0'
+                    - '202001.0'
+                    - '202005.0'
+                - title: Managing transactions log
+                  url: /docs/scos/dev/user-guides/back-office-user-guide/punch-out/managing-transa.html
+                  include_versions:
+                    - '202009.0'
+                    - '202108.0'
+                - title: Managing Punch out connections
+                  url: /docs/scos/dev/user-guides/back-office-user-guide/punch-out/managing-puncho.html
+                  include_versions:
+                    - '202009.0'
+                    - '202108.0'
+            - title: Navigation
+              nested:
+                - title: References
+                  nested:
+                    - title: Navigation Node Types
+                      url: /docs/scos/dev/user-guides/back-office-user-guide/navigation/references/navigation-node.html
+                      include_versions:
+                        - '201811.0'
+                        - '201903.0'
+                        - '201907.0'
+                        - '202001.0'
+                - title: Managing Navigation
+                  url: /docs/scos/dev/user-guides/back-office-user-guide/navigation/managing-naviga.html
+                  include_versions:
+                    - '201811.0'
+                    - '201903.0'
+                    - '201907.0'
+                    - '202001.0'
+                - title: Navigation
+                  url: /docs/scos/dev/user-guides/back-office-user-guide/navigation/navigation-guid.html
+                  include_versions:
+                    - '201811.0'
+                    - '201903.0'
+                    - '201907.0'
+                    - '202001.0'
+            - title: Company account
+              nested:
+                - title: Company Account
+                  url: /docs/scos/dev/user-guides/back-office-user-guide/company-account/company-account.html
+                  include_versions:
+                    - '201811.0'
+                    - '201903.0'
+                    - '201907.0'
+                    - '202001.0'
+                - title: References
+                  nested:
+                    - title: Company Account- Reference Information
+                      url: /docs/scos/dev/user-guides/back-office-user-guide/company-account/references/company-account.html
+                      include_versions:
+                        - '201811.0'
+                        - '201903.0'
+                        - '201907.0'
+                        - '202001.0'
+                - title: Managing a Company Account
+                  nested:
+                    - title: Managing Companies
+                      url: /docs/scos/dev/user-guides/back-office-user-guide/company-account/managing-a-company-account/managing-compan.html
+                      include_versions:
+                        - '201811.0'
+                        - '201903.0'
+                        - '201907.0'
+                        - '202001.0'
+            - title: Discount
+              nested:
+                - title: References
+                  nested:
+                    - title: Discount Conditions- Reference Information
+                      url: /docs/scos/dev/user-guides/back-office-user-guide/discount/references/discount-condit.html
+                      include_versions:
+                        - '201811.0'
+                        - '201903.0'
+                        - '201907.0'
+                        - '202001.0'
+                    - title: Discount- Reference Information
+                      url: /docs/scos/dev/user-guides/back-office-user-guide/discount/references/discount-refere.html
+                      include_versions:
+                        - '201811.0'
+                        - '201903.0'
+                        - '201907.0'
+                        - '202001.0'
+                    - title: Voucher Codes- Reference Information
+                      url: /docs/scos/dev/user-guides/back-office-user-guide/discount/references/voucher-codes-r.html
+                      include_versions:
+                        - '201811.0'
+                        - '201903.0'
+                        - '201907.0'
+                        - '202001.0'
+                    - title: Discount Calculation- Reference Information
+                      url: /docs/scos/dev/user-guides/back-office-user-guide/discount/references/discount-calcul.html
+                      include_versions:
+                        - '201811.0'
+                        - '201903.0'
+                        - '201907.0'
+                        - '202001.0'
+                    - title: Token Description Tables
+                      url: /docs/scos/dev/user-guides/back-office-user-guide/discount/references/token-descripti.html
+                      include_versions:
+                        - '201811.0'
+                        - '201903.0'
+                        - '201907.0'
+                        - '202001.0'
+                - title: Creating a Discount
+                  nested:
+                    - title: Creating a Discount Voucher
+                      url: /docs/scos/dev/user-guides/back-office-user-guide/discount/creating-a-discount/creating-a-disc.html
+                      include_versions:
+                        - '201811.0'
+                        - '201903.0'
+                        - '201907.0'
+                        - '202001.0'
+                    - title: Creating a Cart Rule Discount
+                      url: /docs/scos/dev/user-guides/back-office-user-guide/discount/creating-a-discount/creating-a-cart.html
+                      include_versions:
+                        - '201811.0'
+                        - '201903.0'
+                        - '201907.0'
+                        - '202001.0'
+                - title: Discount
+                  url: /docs/scos/dev/user-guides/back-office-user-guide/discount/discount-1.html
+                  include_versions:
+                    - '201811.0'
+                    - '201903.0'
+                    - '201907.0'
+                    - '202001.0'
+                - title: Managing Discounts
+                  url: /docs/scos/dev/user-guides/back-office-user-guide/discount/managing-discou.html
+                  include_versions:
+                    - '201811.0'
+                    - '201903.0'
+                    - '201907.0'
+                    - '202001.0'
+            - title: Merchants
+              nested:
+                - title: Merchants
+                  url: /docs/scos/dev/user-guides/back-office-user-guide/merchants/merchants.html
+                  include_versions:
+                    - '201903.0'
+                    - '201907.0'
+                    - '202001.0'
+                - title: Merchants and merchant relations
+                  nested:
+                    - title: Managing Merchants
+                      url: /docs/scos/dev/user-guides/back-office-user-guide/merchants/merchants-and-merchant-relations/managing-mercha.html
+                      include_versions:
+                        - '201903.0'
+                        - '201907.0'
+                        - '202001.0'
+            - title: Dashboard
+              nested:
+                - title: Dashboard
+                  url: /docs/scos/dev/user-guides/back-office-user-guide/dashboard/dashboard.html
+                  include_versions:
+                    - '201811.0'
+                    - '201903.0'
+                    - '201907.0'
+                    - '202001.0'
+                    - '202005.0'
+                - title: References
+                  nested:
+                    - title: Dashboard- Reference Information
+                      url: /docs/scos/dev/user-guides/back-office-user-guide/dashboard/references/dashboard-refer.html
+                      include_versions:
+                        - '201811.0'
+                        - '201903.0'
+                        - '201907.0'
+                        - '202001.0'
+                        - '202005.0'
+                - title: Reference information- Dashboard
+                  url: /docs/scos/dev/user-guides/back-office-user-guide/dashboard/reference-infor.html
+                  include_versions:
+                    - '202009.0'
+                    - '202108.0'
+            - title: Price
+              nested:
+                - title: Scheduled prices
+                  nested:
+                    - title: References
+                      nested:
+                        - title: Scheduled Prices- Reference Information
+                          url: /docs/scos/dev/user-guides/back-office-user-guide/price/scheduled-prices/references/scheduled-price.html
+                          include_versions:
+                            - '201907.0'
+                            - '202001.0'
+                    - title: Managing Scheduled Prices
+                      url: /docs/scos/dev/user-guides/back-office-user-guide/price/scheduled-prices/managing-schedu.html
+                      include_versions:
+                        - '202001.0'
+                    - title: Creating Scheduled Prices
+                      url: /docs/scos/dev/user-guides/back-office-user-guide/price/scheduled-prices/creating-schedu.html
+                      include_versions:
+                        - '201907.0'
+                        - '202001.0'
+                    - title: Scheduled Prices
+                      url: /docs/scos/dev/user-guides/back-office-user-guide/price/scheduled-prices/managing-schedu.html
+                      include_versions:
+                        - '201907.0'
+            - title: Taxes
+              nested:
+                - title: Taxes
+                  url: /docs/scos/dev/user-guides/back-office-user-guide/taxes/taxes.html
+                  include_versions:
+                    - '201811.0'
+                    - '201903.0'
+                    - '201907.0'
+                    - '202001.0'
+                - title: Tax Rates and Tax Sets
+                  nested:
+                    - title: References
+                      nested:
+                        - title: Taxes- Reference Information
+                          url: /docs/scos/dev/user-guides/back-office-user-guide/taxes/tax-rates-and-tax-sets/references/taxes-reference.html
+                          include_versions:
+                            - '201811.0'
+                            - '201903.0'
+                            - '201907.0'
+                            - '202001.0'
+                    - title: Managing Tax Rates and Sets
+                      url: /docs/scos/dev/user-guides/back-office-user-guide/taxes/tax-rates-and-tax-sets/managing-tax-ra.html
+                      include_versions:
+                        - '201811.0'
+                        - '201903.0'
+                        - '201907.0'
+                        - '202001.0'
+            - title: Glossary
+              nested:
+                - title: Glossary
+                  url: /docs/scos/dev/user-guides/back-office-user-guide/glossary/glossary.html
+                  include_versions:
+                    - '201811.0'
+                    - '201903.0'
+                    - '201907.0'
+                    - '202001.0'
+                - title: Managing Glossary
+                  url: /docs/scos/dev/user-guides/back-office-user-guide/glossary/managing-glossa.html
+                  include_versions:
+                    - '201811.0'
+                    - '201903.0'
+                    - '201907.0'
+                    - '202001.0'
+            - title: Content Management
+              nested:
+                - title: Blocks
+                  nested:
+                    - title: References
+                      nested:
+                        - title: CMS Block- Reference Information
+                          url: /docs/scos/dev/user-guides/back-office-user-guide/content-management/blocks/references/cms-block-refer.html
+                          include_versions:
+                            - '201811.0'
+                            - '201903.0'
+                            - '201907.0'
+                            - '202001.0'
+                    - title: CMS Block
+                      url: /docs/scos/dev/user-guides/back-office-user-guide/content-management/blocks/cms-block-guide.html
+                      include_versions:
+                        - '201811.0'
+                        - '201903.0'
+                        - '201907.0'
+                        - '202001.0'
+                    - title: Assigning Blocks to Category or Product Pages
+                      url: /docs/scos/dev/user-guides/back-office-user-guide/content-management/blocks/assigning-block.html
+                      include_versions:
+                        - '201811.0'
+                        - '201903.0'
+                        - '201907.0'
+                        - '202001.0'
+                    - title: Defining Validity Period for CMS Blocks
+                      url: /docs/scos/dev/user-guides/back-office-user-guide/content-management/blocks/defining-validi.html
+                      include_versions:
+                        - '201811.0'
+                        - '201903.0'
+                        - '201907.0'
+                        - '202001.0'
+                    - title: Managing CMS Blocks
+                      url: /docs/scos/dev/user-guides/back-office-user-guide/content-management/blocks/managing-cms-bl.html
+                      include_versions:
+                        - '201811.0'
+                        - '201903.0'
+                        - '201907.0'
+                        - '202001.0'
+                    - title: Creating a CMS Block
+                      url: /docs/scos/dev/user-guides/back-office-user-guide/content-management/blocks/creating-cms-bl.html
+                      include_versions:
+                        - '201811.0'
+                        - '201903.0'
+                        - '201907.0'
+                        - '202001.0'
+                - title: Content Management System
+                  url: /docs/scos/dev/user-guides/back-office-user-guide/content-management/cms-guide.html
+                  include_versions:
+                    - '201811.0'
+                    - '201903.0'
+                    - '201907.0'
+                    - '202001.0'
+                - title: Content items
+                  nested:
+                    - title: Content Item Widgets
+                      nested:
+                        - title: Adding Content Item Widgets to Pages and Blocks
+                          url: /docs/scos/dev/user-guides/back-office-user-guide/content-management/content-items/content-item-widgets/adding-content-.html
+                          include_versions:
+                            - '202001.0'
+                        - title: Content Item Widgets
+                          url: /docs/scos/dev/user-guides/back-office-user-guide/content-management/content-items/content-item-widgets/content-item-wi.html
+                          include_versions:
+                            - '202001.0'
+                        - title: References
+                          nested:
+                            - title: Content Item Widgets types- Reference
+                                Information
+                              url: /docs/scos/dev/user-guides/back-office-user-guide/content-management/content-items/content-item-widgets/references/content-item-wi.html
+                              include_versions:
+                                - '202001.0'
+                        - title: Editing Content Item Widgets
+                          url: /docs/scos/dev/user-guides/back-office-user-guide/content-management/content-items/content-item-widgets/editing-content.html
+                          include_versions:
+                            - '202001.0'
+                    - title: References
+                      nested:
+                        - title: Content Items- Reference Information
+                          url: /docs/scos/dev/user-guides/back-office-user-guide/content-management/content-items/references/content-items-r.html
+                          include_versions:
+                            - '201907.0'
+                            - '202001.0'
+                    - title: Editing Content Items
+                      url: /docs/scos/dev/user-guides/back-office-user-guide/content-management/content-items/editing-content.html
+                      include_versions:
+                        - '201907.0'
+                        - '202001.0'
+                    - title: Creating Content Items
+                      url: /docs/scos/dev/user-guides/back-office-user-guide/content-management/content-items/creating-conten.html
+                      include_versions:
+                        - '201907.0'
+                        - '202001.0'
+                    - title: Content Items
+                      url: /docs/scos/dev/user-guides/back-office-user-guide/content-management/content-items/content-items-g.html
+                      include_versions:
+                        - '201907.0'
+                - title: Redirects
+                  nested:
+                    - title: Redirects
+                      url: /docs/scos/dev/user-guides/back-office-user-guide/content-management/redirects/redirects.html
+                      include_versions:
+                        - '201811.0'
+                        - '201903.0'
+                        - '201907.0'
+                        - '202001.0'
+                    - title: References
+                      nested:
+                        - title: CMS Redirects- References
+                          url: /docs/scos/dev/user-guides/back-office-user-guide/content-management/redirects/references/cms-redirects-r.html
+                          include_versions:
+                            - '201811.0'
+                            - '201903.0'
+                            - '201907.0'
+                            - '202001.0'
+                    - title: Creating CMS Redirects
+                      url: /docs/scos/dev/user-guides/back-office-user-guide/content-management/redirects/creating-cms-re.html
+                      include_versions:
+                        - '201811.0'
+                        - '201903.0'
+                        - '201907.0'
+                        - '202001.0'
+                    - title: Managing CMS Redirects
+                      url: /docs/scos/dev/user-guides/back-office-user-guide/content-management/redirects/editing-cms-red.html
+                      include_versions:
+                        - '201811.0'
+                        - '201903.0'
+                        - '201907.0'
+                        - '202001.0'
+                - title: Pages
+                  nested:
+                    - title: References
+                      nested:
+                        - title: CMS Pages- Reference Information
+                          url: /docs/scos/dev/user-guides/back-office-user-guide/content-management/pages/references/cms-pages-refer.html
+                          include_versions:
+                            - '201811.0'
+                            - '201903.0'
+                            - '201907.0'
+                            - '202001.0'
+                    - title: Managing CMS Pages
+                      url: /docs/scos/dev/user-guides/back-office-user-guide/content-management/pages/managing-cms-pa.html
+                      include_versions:
+                        - '201811.0'
+                        - '201903.0'
+                        - '201907.0'
+                        - '202001.0'
+                    - title: CMS Pages
+                      url: /docs/scos/dev/user-guides/back-office-user-guide/content-management/pages/cms-pages.html
+                      include_versions:
+                        - '201811.0'
+                        - '201903.0'
+                        - '201907.0'
+                        - '202001.0'
+                    - title: Editing CMS Pages
+                      url: /docs/scos/dev/user-guides/back-office-user-guide/content-management/pages/editing-cms-pag.html
+                      include_versions:
+                        - '201811.0'
+                        - '201903.0'
+                        - '201907.0'
+                        - '202001.0'
+                    - title: Creating a CMS Page
+                      url: /docs/scos/dev/user-guides/back-office-user-guide/content-management/pages/creating-a-cms-.html
+                      include_versions:
+                        - '201811.0'
+                        - '201903.0'
+                        - '201907.0'
+                        - '202001.0'
+                    - title: CMS Pages Versioning
+                      url: /docs/scos/dev/user-guides/back-office-user-guide/content-management/pages/cms-pages-versi.html
+                      include_versions:
+                        - '201811.0'
+                        - '201903.0'
+                        - '201907.0'
+                        - '202001.0'
+                    - title: Assigning Blocks to Category and Product Pages
+                      url: /docs/scos/dev/user-guides/back-office-user-guide/content-management/pages/assigning-block.html
+                      include_versions:
+                        - '201811.0'
+                        - '201903.0'
+                        - '201907.0'
+                - title: Slots
+                  nested:
+                    - title: Adding Content to Storefront Pages Using Templates &
+                        Slots
+                      url: /docs/scos/dev/user-guides/back-office-user-guide/content-management/slots/adding-content-.html
+                      include_versions:
+                        - '202001.0'
+                    - title: References
+                      nested:
+                        - title: Slots- Reference Information
+                          url: /docs/scos/dev/user-guides/back-office-user-guide/content-management/slots/references/slots-reference.html
+                          include_versions:
+                            - '202001.0'
+                    - title: Managing Slots
+                      url: /docs/scos/dev/user-guides/back-office-user-guide/content-management/slots/managing-slots.html
+                      include_versions:
+                        - '202001.0'
+                    - title: Slots
+                      url: /docs/scos/dev/user-guides/back-office-user-guide/content-management/slots/slots.html
+                      include_versions:
+                        - '202001.0'
+                - title: Content Item Widgets
+                  nested:
+                    - title: Adding Content Item Widgets to Pages and Blocks
+                      url: /docs/scos/dev/user-guides/back-office-user-guide/content-management/content-item-widgets/adding-content-.html
+                      include_versions:
+                        - '201907.0'
+                    - title: Content Item Widgets
+                      url: /docs/scos/dev/user-guides/back-office-user-guide/content-management/content-item-widgets/content-item-wi.html
+                      include_versions:
+                        - '201907.0'
+                    - title: References
+                      nested:
+                        - title: Content Item Widgets types- Reference Information
+                          url: /docs/scos/dev/user-guides/back-office-user-guide/content-management/content-item-widgets/references/content-item-wi.html
+                          include_versions:
+                            - '201907.0'
+                    - title: Editing Content Item Widgets
+                      url: /docs/scos/dev/user-guides/back-office-user-guide/content-management/content-item-widgets/editing-content.html
+                      include_versions:
+                        - '201907.0'
+                - title: Content Widgets
+                  nested:
+                    - title: Content Widgets
+                      url: /docs/scos/dev/user-guides/back-office-user-guide/content-management/content-widgets/content-widgets.html
+                      include_versions:
+                        - '201903.0'
+            - title: Maintenance
+              nested:
+                - title: Maintenance
+                  url: /docs/scos/dev/user-guides/back-office-user-guide/maintenance/maintenance.html
+                  include_versions:
+                    - '201811.0'
+                    - '201903.0'
+                    - '201907.0'
+                    - '202001.0'
+                    - '202005.0'
+            - title: Administration
+              nested:
+                - title: Warehouses
+                  nested:
+                    - title: References
+                      nested:
+                        - title: Warehouses- Reference Information
+                          url: /docs/scos/dev/user-guides/back-office-user-guide/administration/warehouses/references/warehouses-refe.html
+                          include_versions:
+                            - '202001.0'
+                            - '202005.0'
+                        - title: Reference information- Warehouses
+                          url: /docs/scos/dev/user-guides/back-office-user-guide/administration/warehouses/references/warehouses-refe.html
+                          include_versions:
+                            - '202009.0'
+                            - '202108.0'
+                    - title: Creating a Warehouse
+                      url: /docs/scos/dev/user-guides/back-office-user-guide/administration/warehouses/creating-a-ware.html
+                      include_versions:
+                        - '202001.0'
+                        - '202005.0'
+                    - title: Managing Warehouses
+                      url: /docs/scos/dev/user-guides/back-office-user-guide/administration/warehouses/managing-wareho.html
+                      include_versions:
+                        - '202001.0'
+                        - '202005.0'
+                    - title: Creating a warehouse
+                      url: /docs/scos/dev/user-guides/back-office-user-guide/administration/warehouses/creating-a-ware.html
+                      include_versions:
+                        - '202009.0'
+                        - '202108.0'
+                    - title: Managing warehouses
+                      url: /docs/scos/dev/user-guides/back-office-user-guide/administration/warehouses/managing-wareho.html
+                      include_versions:
+                        - '202009.0'
+                        - '202108.0'
+                - title: Payment Management
+                  nested:
+                    - title: References
+                      nested:
+                        - title: Payment Methods- Reference Information
+                          url: /docs/scos/dev/user-guides/back-office-user-guide/administration/payment-management/references/payment-methods.html
+                          include_versions:
+                            - '202001.0'
+                    - title: Managing Payment Methods
+                      url: /docs/scos/dev/user-guides/back-office-user-guide/administration/payment-management/managing-paymen.html
+                      include_versions:
+                        - '202001.0'
+                - title: Administration
+                  url: /docs/scos/dev/user-guides/back-office-user-guide/administration/administration-.html
+                  include_versions:
+                    - '202001.0'
+                    - '202005.0'
+                - title: Stores
+                  url: /docs/scos/dev/user-guides/back-office-user-guide/administration/stores-referenc.html
+                  include_versions:
+                    - '202001.0'
+                    - '202005.0'
+                    - '202009.0'
+                    - '202108.0'
+                - title: Shipment
+                  nested:
+                    - title: References
+                      nested:
+                        - title: Delivery Methods- Reference Information
+                          url: /docs/scos/dev/user-guides/back-office-user-guide/administration/shipment/references/delivery-method.html
+                          include_versions:
+                            - '202001.0'
+                    - title: Shipment
+                      url: /docs/scos/dev/user-guides/back-office-user-guide/administration/shipment/shipment-manage.html
+                      include_versions:
+                        - '201903.0'
+                        - '202001.0'
+                    - title: Creating a Carrier Company
+                      url: /docs/scos/dev/user-guides/back-office-user-guide/administration/shipment/creating-a-carr.html
+                      include_versions:
+                        - '201903.0'
+                        - '202001.0'
+                    - title: Creating and Managing Delivery Methods
+                      url: /docs/scos/dev/user-guides/back-office-user-guide/administration/shipment/creating-and-ma.html
+                      include_versions:
+                        - '202001.0'
+                    - title: Creating and Managing Shipment Methods
+                      url: /docs/scos/dev/user-guides/back-office-user-guide/administration/shipment/creating-and-ma.html
+                      include_versions:
+                        - '201903.0'
+                - title: MIME type settings
+                  nested:
+                    - title: Managing MIME Type Settings
+                      url: /docs/scos/dev/user-guides/back-office-user-guide/administration/mime-type-settings/managing-mime-t.html
+                      include_versions:
+                        - '202005.0'
+                    - title: Managing MIME type settings
+                      url: /docs/scos/dev/user-guides/back-office-user-guide/administration/mime-type-settings/managing-mime-t.html
+                      include_versions:
+                        - '202009.0'
+                        - '202108.0'
+                - title: Thresholds
+                  nested:
+                    - title: Threshold
+                      url: /docs/scos/dev/user-guides/back-office-user-guide/administration/thresholds/threshold.html
+                      include_versions:
+                        - '202005.0'
+                        - '202009.0'
+                    - title: References
+                      nested:
+                        - title: Threshold- Reference Information
+                          url: /docs/scos/dev/user-guides/back-office-user-guide/administration/thresholds/references/threshold-refer.html
+                          include_versions:
+                            - '202005.0'
+                        - title: Reference information- Threshold
+                          url: /docs/scos/dev/user-guides/back-office-user-guide/administration/thresholds/references/threshold-refer.html
+                          include_versions:
+                            - '202009.0'
+                            - '202108.0'
+                    - title: Threshold Settings
+                      nested:
+                        - title: Managing Threshold Settings
+                          url: /docs/scos/dev/user-guides/back-office-user-guide/administration/thresholds/threshold-settings/managing-thresh.html
+                          include_versions:
+                            - '202005.0'
+                    - title: Global Threshold
+                      nested:
+                        - title: Managing Global Threshold
+                          url: /docs/scos/dev/user-guides/back-office-user-guide/administration/thresholds/global-threshold/managing-global.html
+                          include_versions:
+                            - '202005.0'
+                    - title: Merchant Relationships
+                      nested:
+                        - title: Managing Merchant Relationships Thresholds
+                          url: /docs/scos/dev/user-guides/back-office-user-guide/administration/thresholds/merchant-relationships/managing-mercha.html
+                          include_versions:
+                            - '202005.0'
+                    - title: Managing merchant order thresholds
+                      url: /docs/scos/dev/user-guides/back-office-user-guide/administration/thresholds/managing-mercha.html
+                      include_versions:
+                        - '202009.0'
+                        - '202108.0'
+                    - title: Managing threshold settings
+                      url: /docs/scos/dev/user-guides/back-office-user-guide/administration/thresholds/managing-thresh.html
+                      include_versions:
+                        - '202009.0'
+                        - '202108.0'
+                    - title: Managing global thresholds
+                      url: /docs/scos/dev/user-guides/back-office-user-guide/administration/thresholds/managing-global.html
+                      include_versions:
+                        - '202009.0'
+                        - '202108.0'
+                - title: Taxes
+                  nested:
+                    - title: Taxes
+                      url: /docs/scos/dev/user-guides/back-office-user-guide/administration/taxes/taxes.html
+                      include_versions:
+                        - '202005.0'
+                    - title: Tax Rates and Tax Sets
+                      nested:
+                        - title: References
+                          nested:
+                            - title: Taxes- Reference Information
+                              url: /docs/scos/dev/user-guides/back-office-user-guide/administration/taxes/tax-rates-and-tax-sets/references/taxes-reference.html
+                              include_versions:
+                                - '202005.0'
+                        - title: Managing Tax Rates and Sets
+                          url: /docs/scos/dev/user-guides/back-office-user-guide/administration/taxes/tax-rates-and-tax-sets/managing-tax-ra.html
+                          include_versions:
+                            - '202005.0'
+                - title: Glossary
+                  nested:
+                    - title: Glossary
+                      url: /docs/scos/dev/user-guides/back-office-user-guide/administration/glossary/glossary.html
+                      include_versions:
+                        - '202005.0'
+                    - title: Managing Glossary
+                      url: /docs/scos/dev/user-guides/back-office-user-guide/administration/glossary/managing-glossa.html
+                      include_versions:
+                        - '202005.0'
+                    - title: Managing glossary
+                      url: /docs/scos/dev/user-guides/back-office-user-guide/administration/glossary/managing-glossa.html
+                      include_versions:
+                        - '202009.0'
+                        - '202108.0'
+                - title: Payment methods
+                  nested:
+                    - title: References
+                      nested:
+                        - title: Payment Methods- Reference Information
+                          url: /docs/scos/dev/user-guides/back-office-user-guide/administration/payment-methods/references/payment-methods.html
+                          include_versions:
+                            - '202005.0'
+                        - title: Reference information- Payment methods
+                          url: /docs/scos/dev/user-guides/back-office-user-guide/administration/payment-methods/references/payment-methods.html
+                          include_versions:
+                            - '202009.0'
+                            - '202108.0'
+                    - title: Managing Payment Methods
+                      url: /docs/scos/dev/user-guides/back-office-user-guide/administration/payment-methods/managing-paymen.html
+                      include_versions:
+                        - '202005.0'
+                    - title: Managing payment methods
+                      url: /docs/scos/dev/user-guides/back-office-user-guide/administration/payment-methods/managing-paymen.html
+                      include_versions:
+                        - '202009.0'
+                        - '202108.0'
+                - title: Delivery methods
+                  nested:
+                    - title: References
+                      nested:
+                        - title: Delivery Methods- Reference Information
+                          url: /docs/scos/dev/user-guides/back-office-user-guide/administration/delivery-methods/references/delivery-method.html
+                          include_versions:
+                            - '202005.0'
+                        - title: Reference information- Delivery methods
+                          url: /docs/scos/dev/user-guides/back-office-user-guide/administration/delivery-methods/references/delivery-method.html
+                          include_versions:
+                            - '202009.0'
+                            - '202108.0'
+                    - title: Delivery Methods
+                      url: /docs/scos/dev/user-guides/back-office-user-guide/administration/delivery-methods/delivery-method.html
+                      include_versions:
+                        - '202005.0'
+                    - title: Creating a Carrier Company
+                      url: /docs/scos/dev/user-guides/back-office-user-guide/administration/delivery-methods/creating-a-carr.html
+                      include_versions:
+                        - '202005.0'
+                    - title: Creating and Managing Delivery Methods
+                      url: /docs/scos/dev/user-guides/back-office-user-guide/administration/delivery-methods/creating-and-ma.html
+                      include_versions:
+                        - '202005.0'
+                    - title: Creating a carrier company
+                      url: /docs/scos/dev/user-guides/back-office-user-guide/administration/delivery-methods/creating-a-carr.html
+                      include_versions:
+                        - '202009.0'
+                        - '202108.0'
+                    - title: Creating and managing delivery methods
+                      url: /docs/scos/dev/user-guides/back-office-user-guide/administration/delivery-methods/creating-and-ma.html
+                      include_versions:
+                        - '202009.0'
+                        - '202108.0'
+                - title: Tax rates
+                  nested:
+                    - title: Managing tax rates
+                      url: /docs/scos/dev/user-guides/back-office-user-guide/administration/tax-rates/managing-tax-ra.html
+                      include_versions:
+                        - '202009.0'
+                        - '202108.0'
+                - title: Tax sets
+                  nested:
+                    - title: Managing tax sets
+                      url: /docs/scos/dev/user-guides/back-office-user-guide/administration/tax-sets/managing-tax-se.html
+                      include_versions:
+                        - '202009.0'
+                        - '202108.0'
+            - title: Users Control
+              nested:
+                - title: 'Roles, groups and users'
+                  nested:
+                    - title: References
+                      nested:
+                        - title: Roles- Reference Information
+                          url: /docs/scos/dev/user-guides/back-office-user-guide/users-control/roles-groups-and-users/references/roles-reference.html
+                          include_versions:
+                            - '201811.0'
+                            - '201903.0'
+                            - '201907.0'
+                            - '202001.0'
+                        - title: User- Reference Information
+                          url: /docs/scos/dev/user-guides/back-office-user-guide/users-control/roles-groups-and-users/references/user-reference-.html
+                          include_versions:
+                            - '201811.0'
+                            - '201903.0'
+                            - '201907.0'
+                            - '202001.0'
+                    - title: Managing Roles
+                      url: /docs/scos/dev/user-guides/back-office-user-guide/users-control/roles-groups-and-users/managing-roles.html
+                      include_versions:
+                        - '201811.0'
+                        - '201903.0'
+                        - '201907.0'
+                        - '202001.0'
+                    - title: Managing Users
+                      url: /docs/scos/dev/user-guides/back-office-user-guide/users-control/roles-groups-and-users/managing-users.html
+                      include_versions:
+                        - '201811.0'
+                        - '201903.0'
+                        - '201907.0'
+                        - '202001.0'
+                    - title: Managing Groups
+                      url: /docs/scos/dev/user-guides/back-office-user-guide/users-control/roles-groups-and-users/managing-groups.html
+                      include_versions:
+                        - '201811.0'
+                        - '201903.0'
+                        - '201907.0'
+                        - '202001.0'
+                - title: Users Control
+                  url: /docs/scos/dev/user-guides/back-office-user-guide/users-control/users-control.html
+                  include_versions:
+                    - '201811.0'
+                    - '201903.0'
+                    - '201907.0'
+                    - '202001.0'
+            - title: File Manager
+              nested:
+                - title: File Manager
+                  url: /docs/scos/dev/user-guides/back-office-user-guide/file-manager/file-manager.html
+                  include_versions:
+                    - '201811.0'
+                    - '201903.0'
+                    - '201907.0'
+                    - '202001.0'
+                - title: Managing File Tree
+                  url: /docs/scos/dev/user-guides/back-office-user-guide/file-manager/managing-file-t.html
+                  include_versions:
+                    - '201811.0'
+                    - '201903.0'
+                    - '201907.0'
+                    - '202001.0'
+                - title: Managing File List
+                  url: /docs/scos/dev/user-guides/back-office-user-guide/file-manager/managing-file-l.html
+                  include_versions:
+                    - '201811.0'
+                    - '201903.0'
+                    - '201907.0'
+                    - '202001.0'
+                - title: Managing MIME Type Settings
+                  url: /docs/scos/dev/user-guides/back-office-user-guide/file-manager/managing-mime-t.html
+                  include_versions:
+                    - '201811.0'
+                    - '201903.0'
+                    - '201907.0'
+                    - '202001.0'
+            - title: Search and filters
+              nested:
+                - title: Managing Category Filters
+                  url: /docs/scos/dev/user-guides/back-office-user-guide/search-and-filters/managing-catego.html
+                  include_versions:
+                    - '201811.0'
+                    - '201903.0'
+                    - '201907.0'
+                    - '202001.0'
+                - title: References
+                  nested:
+                    - title: Reference- Search Preferences
+                      url: /docs/scos/dev/user-guides/back-office-user-guide/search-and-filters/references/reference-searc.html
+                      include_versions:
+                        - '201811.0'
+                        - '201903.0'
+                        - '201907.0'
+                        - '202001.0'
+                    - title: Search Preferences Types
+                      url: /docs/scos/dev/user-guides/back-office-user-guide/search-and-filters/references/search-preferen.html
+                      include_versions:
+                        - '201811.0'
+                        - '201903.0'
+                        - '201907.0'
+                        - '202001.0'
+                - title: Managing Search Preferences
+                  url: /docs/scos/dev/user-guides/back-office-user-guide/search-and-filters/managing-search.html
+                  include_versions:
+                    - '201811.0'
+                    - '201903.0'
+                    - '201907.0'
+                    - '202001.0'
+                - title: Managing Filter Preferences
+                  url: /docs/scos/dev/user-guides/back-office-user-guide/search-and-filters/managing-filter.html
+                  include_versions:
+                    - '201811.0'
+                    - '201903.0'
+                    - '201907.0'
+                    - '202001.0'
+                - title: Search and Filters
+                  url: /docs/scos/dev/user-guides/back-office-user-guide/search-and-filters/search-and-filt.html
+                  include_versions:
+                    - '201811.0'
+                    - '201903.0'
+                    - '201907.0'
+                    - '202001.0'
+            - title: About the Administration Interface Guide
+              url: /docs/scos/dev/user-guides/back-office-user-guide/about-the-back-.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+            - title: Catalog
+              nested:
+                - title: Product reviews
+                  nested:
+                    - title: Product Reviews
+                      url: /docs/scos/dev/user-guides/back-office-user-guide/catalog/product-reviews/product-reviews.html
+                      include_versions:
+                        - '202005.0'
+                    - title: Managing Product Reviews
+                      url: /docs/scos/dev/user-guides/back-office-user-guide/catalog/product-reviews/managing-produc.html
+                      include_versions:
+                        - '202005.0'
+                    - title: Managing product reviews
+                      url: /docs/scos/dev/user-guides/back-office-user-guide/catalog/product-reviews/managing-produc.html
+                      include_versions:
+                        - '202009.0'
+                        - '202108.0'
+                - title: Products
+                  nested:
+                    - title: References
+                      nested:
+                        - title: Concrete Product- Reference Information
+                          url: /docs/scos/dev/user-guides/back-office-user-guide/catalog/products/references/concrete-produc.html
+                          include_versions:
+                            - '202005.0'
+                        - title: Products- Reference Information
+                          url: /docs/scos/dev/user-guides/back-office-user-guide/catalog/products/references/products-refere.html
+                          include_versions:
+                            - '202005.0'
+                        - title: Abstract Product- Reference Information
+                          url: /docs/scos/dev/user-guides/back-office-user-guide/catalog/products/references/abstract-produc.html
+                          include_versions:
+                            - '202005.0'
+                        - title: Reference information- concrete product
+                          url: /docs/scos/dev/user-guides/back-office-user-guide/catalog/products/references/concrete-produc.html
+                          include_versions:
+                            - '202009.0'
+                            - '202108.0'
+                        - title: Reference information- products
+                          url: /docs/scos/dev/user-guides/back-office-user-guide/catalog/products/references/products-refere.html
+                          include_versions:
+                            - '202009.0'
+                            - '202108.0'
+                        - title: Reference information- abstract product
+                          url: /docs/scos/dev/user-guides/back-office-user-guide/catalog/products/references/abstract-produc.html
+                          include_versions:
+                            - '202009.0'
+                            - '202108.0'
+                    - title: Abstract and Concrete Products
+                      url: /docs/scos/dev/user-guides/back-office-user-guide/catalog/products/abstract-and-co.html
+                      include_versions:
+                        - '202005.0'
+                    - title: Concrete products
+                      nested:
+                        - title: Updating a Product Variant
+                          url: /docs/scos/dev/user-guides/back-office-user-guide/catalog/products/concrete-products/updating-a-prod.html
+                          include_versions:
+                            - '202005.0'
+                        - title: Creating a Product Variant
+                          url: /docs/scos/dev/user-guides/back-office-user-guide/catalog/products/concrete-products/creating-a-prod.html
+                          include_versions:
+                            - '202005.0'
+                        - title: Editing a product variant
+                          url: /docs/scos/dev/user-guides/back-office-user-guide/catalog/products/concrete-products/editing-a-produ.html
+                          include_versions:
+                            - '202009.0'
+                            - '202108.0'
+                        - title: Creating a product variant
+                          url: /docs/scos/dev/user-guides/back-office-user-guide/catalog/products/concrete-products/creating-a-prod.html
+                          include_versions:
+                            - '202009.0'
+                            - '202108.0'
+                    - title: Creating Service Offerings
+                      url: /docs/scos/dev/user-guides/back-office-user-guide/catalog/products/creating-servic.html
+                      include_versions:
+                        - '202005.0'
+                    - title: Managing products
+                      nested:
+                        - title: Discontinuing a Product
+                          url: /docs/scos/dev/user-guides/back-office-user-guide/catalog/products/managing-products/discontinuing-a.html
+                          include_versions:
+                            - '202005.0'
+                        - title: Adding Product Alternatives
+                          url: /docs/scos/dev/user-guides/back-office-user-guide/catalog/products/managing-products/adding-product-.html
+                          include_versions:
+                            - '202005.0'
+                        - title: Managing Products
+                          url: /docs/scos/dev/user-guides/back-office-user-guide/catalog/products/managing-products/managing-produc.html
+                          include_versions:
+                            - '202005.0'
+                        - title: Creating Product Bundles
+                          url: /docs/scos/dev/user-guides/back-office-user-guide/catalog/products/managing-products/creating-produc.html
+                          include_versions:
+                            - '202005.0'
+                        - title: Adding Volume Prices
+                          url: /docs/scos/dev/user-guides/back-office-user-guide/catalog/products/managing-products/adding-volume-p.html
+                          include_versions:
+                            - '202005.0'
+                        - title: Discontinuing a product
+                          url: /docs/scos/dev/user-guides/back-office-user-guide/catalog/products/managing-products/discontinuing-a.html
+                          include_versions:
+                            - '202009.0'
+                            - '202108.0'
+                        - title: Adding product alternatives
+                          url: /docs/scos/dev/user-guides/back-office-user-guide/catalog/products/managing-products/adding-product-.html
+                          include_versions:
+                            - '202009.0'
+                            - '202108.0'
+                        - title: Managing products
+                          url: /docs/scos/dev/user-guides/back-office-user-guide/catalog/products/managing-products/managing-produc.html
+                          include_versions:
+                            - '202009.0'
+                            - '202108.0'
+                    - title: Abstract products
+                      nested:
+                        - title: Creating an Abstract Product
+                          url: /docs/scos/dev/user-guides/back-office-user-guide/catalog/products/abstract-products/creating-an-abs.html
+                          include_versions:
+                            - '202005.0'
+                        - title: Editing an Abstract Product
+                          url: /docs/scos/dev/user-guides/back-office-user-guide/catalog/products/abstract-products/editing-an-abst.html
+                          include_versions:
+                            - '202005.0'
+                        - title: Adding scheduled prices to abstract products
+                          url: /docs/scos/dev/user-guides/back-office-user-guide/catalog/products/abstract-products/adding-schedule.html
+                          include_versions:
+                            - '202009.0'
+                            - '202108.0'
+                        - title: Editing abstract products
+                          url: /docs/scos/dev/user-guides/back-office-user-guide/catalog/products/abstract-products/editing-abstrac.html
+                          include_versions:
+                            - '202009.0'
+                            - '202108.0'
+                        - title: Creating abstract products and product bundles
+                          url: /docs/scos/dev/user-guides/back-office-user-guide/catalog/products/abstract-products/creating-abstra.html
+                          include_versions:
+                            - '202009.0'
+                            - '202108.0'
+                        - title: Creating product bundles
+                          url: /docs/scos/dev/user-guides/back-office-user-guide/catalog/products/abstract-products/creating-produc.html
+                          include_versions:
+                            - '202009.0'
+                            - '202108.0'
+                        - title: Adding volume prices to abstract products
+                          url: /docs/scos/dev/user-guides/back-office-user-guide/catalog/products/abstract-products/adding-volume-p.html
+                          include_versions:
+                            - '202009.0'
+                            - '202108.0'
+                    - title: Creating service offerings- best practices
+                      url: /docs/scos/dev/user-guides/back-office-user-guide/catalog/products/creating-servic.html
+                      include_versions:
+                        - '202009.0'
+                        - '202108.0'
+                - title: Category
+                  nested:
+                    - title: Creating Categories
+                      url: /docs/scos/dev/user-guides/back-office-user-guide/catalog/category/creating-catego.html
+                      include_versions:
+                        - '202005.0'
+                    - title: Managing Categories
+                      url: /docs/scos/dev/user-guides/back-office-user-guide/catalog/category/managing-catego.html
+                      include_versions:
+                        - '202005.0'
+                    - title: References
+                      nested:
+                        - title: Category- Reference Information
+                          url: /docs/scos/dev/user-guides/back-office-user-guide/catalog/category/references/category-refere.html
+                          include_versions:
+                            - '202005.0'
+                        - title: Reference information- category
+                          url: /docs/scos/dev/user-guides/back-office-user-guide/catalog/category/references/category-refere.html
+                          include_versions:
+                            - '202009.0'
+                            - '202108.0'
+                    - title: Category
+                      url: /docs/scos/dev/user-guides/back-office-user-guide/catalog/category/category.html
+                      include_versions:
+                        - '202005.0'
+                    - title: Assigning Products to Categories
+                      url: /docs/scos/dev/user-guides/back-office-user-guide/catalog/category/assigning-produ.html
+                      include_versions:
+                        - '202005.0'
+                    - title: Creating categories
+                      url: /docs/scos/dev/user-guides/back-office-user-guide/catalog/category/creating-catego.html
+                      include_versions:
+                        - '202009.0'
+                        - '202108.0'
+                    - title: Managing categories
+                      url: /docs/scos/dev/user-guides/back-office-user-guide/catalog/category/managing-catego.html
+                      include_versions:
+                        - '202009.0'
+                        - '202108.0'
+                    - title: Assigning products to categories
+                      url: /docs/scos/dev/user-guides/back-office-user-guide/catalog/category/assigning-produ.html
+                      include_versions:
+                        - '202009.0'
+                        - '202108.0'
+                - title: Attributes
+                  nested:
+                    - title: Managing Attributes
+                      url: /docs/scos/dev/user-guides/back-office-user-guide/catalog/attributes/managing-attrib.html
+                      include_versions:
+                        - '202005.0'
+                    - title: References
+                      nested:
+                        - title: Attributes- Reference Information
+                          url: /docs/scos/dev/user-guides/back-office-user-guide/catalog/attributes/references/attributes-refe.html
+                          include_versions:
+                            - '202005.0'
+                        - title: Reference information- product attributes
+                          url: /docs/scos/dev/user-guides/back-office-user-guide/catalog/attributes/references/reference-infor.html
+                          include_versions:
+                            - '202009.0'
+                    - title: Creating a Product Attribute
+                      url: /docs/scos/dev/user-guides/back-office-user-guide/catalog/attributes/creating-a-prod.html
+                      include_versions:
+                        - '202005.0'
+                    - title: Attributes
+                      url: /docs/scos/dev/user-guides/back-office-user-guide/catalog/attributes/attributes.html
+                      include_versions:
+                        - '202005.0'
+                    - title: Managing product attributes
+                      url: /docs/scos/dev/user-guides/back-office-user-guide/catalog/attributes/managing-attrib.html
+                      include_versions:
+                        - '202009.0'
+                        - '202108.0'
+                    - title: Creating product attributes
+                      url: /docs/scos/dev/user-guides/back-office-user-guide/catalog/attributes/creating-produc.html
+                      include_versions:
+                        - '202009.0'
+                        - '202108.0'
+                - title: Catalog
+                  url: /docs/scos/dev/user-guides/back-office-user-guide/catalog/catalog.html
+                  include_versions:
+                    - '202005.0'
+                - title: Availability
+                  nested:
+                    - title: References
+                      nested:
+                        - title: Availability- Reference Information
+                          url: /docs/scos/dev/user-guides/back-office-user-guide/catalog/availability/references/availability-re.html
+                          include_versions:
+                            - '202005.0'
+                        - title: Reference information- availability
+                          url: /docs/scos/dev/user-guides/back-office-user-guide/catalog/availability/references/availability-re.html
+                          include_versions:
+                            - '202009.0'
+                    - title: Managing Products Availability
+                      url: /docs/scos/dev/user-guides/back-office-user-guide/catalog/availability/managing-produc.html
+                      include_versions:
+                        - '202005.0'
+                    - title: Managing products availability
+                      url: /docs/scos/dev/user-guides/back-office-user-guide/catalog/availability/managing-produc.html
+                      include_versions:
+                        - '202009.0'
+                        - '202108.0'
+                - title: Product lists
+                  nested:
+                    - title: References
+                      nested:
+                        - title: Product Lists- Reference Information
+                          url: /docs/scos/dev/user-guides/back-office-user-guide/catalog/product-lists/references/product-lists-r.html
+                          include_versions:
+                            - '202005.0'
+                        - title: Reference information- product lists
+                          url: /docs/scos/dev/user-guides/back-office-user-guide/catalog/product-lists/references/product-lists-r.html
+                          include_versions:
+                            - '202009.0'
+                    - title: Creating a Product List
+                      url: /docs/scos/dev/user-guides/back-office-user-guide/catalog/product-lists/creating-a-prod.html
+                      include_versions:
+                        - '202005.0'
+                    - title: Managing Product Lists
+                      url: /docs/scos/dev/user-guides/back-office-user-guide/catalog/product-lists/managing-produc.html
+                      include_versions:
+                        - '202005.0'
+                    - title: Product Lists
+                      url: /docs/scos/dev/user-guides/back-office-user-guide/catalog/product-lists/product-lists.html
+                      include_versions:
+                        - '202005.0'
+                    - title: Creating a product list
+                      url: /docs/scos/dev/user-guides/back-office-user-guide/catalog/product-lists/creating-a-prod.html
+                      include_versions:
+                        - '202009.0'
+                        - '202108.0'
+                    - title: Managing product lists
+                      url: /docs/scos/dev/user-guides/back-office-user-guide/catalog/product-lists/managing-produc.html
+                      include_versions:
+                        - '202009.0'
+                        - '202108.0'
+                - title: Product options
+                  nested:
+                    - title: References
+                      nested:
+                        - title: Product Options- Reference Information
+                          url: /docs/scos/dev/user-guides/back-office-user-guide/catalog/product-options/references/product-options.html
+                          include_versions:
+                            - '202005.0'
+                        - title: Reference information- product options
+                          url: /docs/scos/dev/user-guides/back-office-user-guide/catalog/product-options/references/product-options.html
+                          include_versions:
+                            - '202009.0'
+                    - title: Product Options
+                      url: /docs/scos/dev/user-guides/back-office-user-guide/catalog/product-options/product-options.html
+                      include_versions:
+                        - '202005.0'
+                    - title: Creating a Product Option
+                      url: /docs/scos/dev/user-guides/back-office-user-guide/catalog/product-options/creating-a-prod.html
+                      include_versions:
+                        - '202005.0'
+                    - title: Managing Product Options
+                      url: /docs/scos/dev/user-guides/back-office-user-guide/catalog/product-options/managing-produc.html
+                      include_versions:
+                        - '202005.0'
+                    - title: Creating a product option
+                      url: /docs/scos/dev/user-guides/back-office-user-guide/catalog/product-options/creating-a-prod.html
+                      include_versions:
+                        - '202009.0'
+                        - '202108.0'
+                    - title: Managing product options
+                      url: /docs/scos/dev/user-guides/back-office-user-guide/catalog/product-options/managing-produc.html
+                      include_versions:
+                        - '202009.0'
+                        - '202108.0'
+                - title: Scheduled prices
+                  nested:
+                    - title: References
+                      nested:
+                        - title: Scheduled Prices- Reference Information
+                          url: /docs/scos/dev/user-guides/back-office-user-guide/catalog/scheduled-prices/references/scheduled-price.html
+                          include_versions:
+                            - '202005.0'
+                        - title: Reference information- scheduled prices
+                          url: /docs/scos/dev/user-guides/back-office-user-guide/catalog/scheduled-prices/references/scheduled-price.html
+                          include_versions:
+                            - '202009.0'
+                            - '202108.0'
+                    - title: Managing Scheduled Prices
+                      url: /docs/scos/dev/user-guides/back-office-user-guide/catalog/scheduled-prices/managing-schedu.html
+                      include_versions:
+                        - '202005.0'
+                    - title: Creating Scheduled Prices
+                      url: /docs/scos/dev/user-guides/back-office-user-guide/catalog/scheduled-prices/creating-schedu.html
+                      include_versions:
+                        - '202005.0'
+                    - title: Managing scheduled prices
+                      url: /docs/scos/dev/user-guides/back-office-user-guide/catalog/scheduled-prices/managing-schedu.html
+                      include_versions:
+                        - '202009.0'
+                        - '202108.0'
+                    - title: Creating scheduled prices
+                      url: /docs/scos/dev/user-guides/back-office-user-guide/catalog/scheduled-prices/creating-schedu.html
+                      include_versions:
+                        - '202009.0'
+                        - '202108.0'
+                - title: Product barcodes
+                  nested:
+                    - title: Product Barcodes
+                      url: /docs/scos/dev/user-guides/back-office-user-guide/catalog/product-barcodes/product-barcode.html
+                      include_versions:
+                        - '202005.0'
+                    - title: Viewing product barcodes
+                      url: /docs/scos/dev/user-guides/back-office-user-guide/catalog/product-barcodes/viewing-product.html
+                      include_versions:
+                        - '202009.0'
+                        - '202108.0'
+            - title: Marketplace
+              nested:
+                - title: Marketplace
+                  url: /docs/scos/dev/user-guides/back-office-user-guide/marketplace/marketplace.html
+                  include_versions:
+                    - '202005.0'
+                - title: Merchants and merchant relations
+                  nested:
+                    - title: Managing Merchants
+                      url: /docs/scos/dev/user-guides/back-office-user-guide/marketplace/merchants-and-merchant-relations/managing-mercha.html
+                      include_versions:
+                        - '202005.0'
+                    - title: Managing merchants
+                      url: /docs/scos/dev/user-guides/back-office-user-guide/marketplace/merchants-and-merchant-relations/managing-mercha.html
+                      include_versions:
+                        - '202009.0'
+                        - '202108.0'
+            - title: Content
+              nested:
+                - title: Blocks
+                  nested:
+                    - title: References
+                      nested:
+                        - title: CMS Block- Reference Information
+                          url: /docs/scos/dev/user-guides/back-office-user-guide/content/blocks/references/cms-block-refer.html
+                          include_versions:
+                            - '202005.0'
+                        - title: Reference information- CMS block
+                          url: /docs/scos/dev/user-guides/back-office-user-guide/content/blocks/references/cms-block-refer.html
+                          include_versions:
+                            - '202009.0'
+                    - title: CMS Block
+                      url: /docs/scos/dev/user-guides/back-office-user-guide/content/blocks/cms-block-guide.html
+                      include_versions:
+                        - '202005.0'
+                    - title: Managing CMS Blocks
+                      url: /docs/scos/dev/user-guides/back-office-user-guide/content/blocks/managing-cms-bl.html
+                      include_versions:
+                        - '202005.0'
+                    - title: Creating a CMS Block
+                      url: /docs/scos/dev/user-guides/back-office-user-guide/content/blocks/creating-cms-bl.html
+                      include_versions:
+                        - '202005.0'
+                    - title: Managing CMS blocks
+                      url: /docs/scos/dev/user-guides/back-office-user-guide/content/blocks/managing-cms-bl.html
+                      include_versions:
+                        - '202009.0'
+                        - '202108.0'
+                    - title: Creating a CMS block
+                      url: /docs/scos/dev/user-guides/back-office-user-guide/content/blocks/creating-cms-bl.html
+                      include_versions:
+                        - '202009.0'
+                        - '202108.0'
+                    - title: Managing content of emails via CMS blocks
+                      url: /docs/scos/dev/user-guides/back-office-user-guide/content/blocks/managing-conten.html
+                      include_versions:
+                        - '202009.0'
+                        - '202108.0'
+                - title: Adding Content to Storefront Pages Using Templates & Slots
+                  url: /docs/scos/dev/user-guides/back-office-user-guide/content/adding-content-.html
+                  include_versions:
+                    - '202005.0'
+                - title: Content items
+                  nested:
+                    - title: Adding Content Items to CMS Pages and Blocks
+                      url: /docs/scos/dev/user-guides/back-office-user-guide/content/content-items/adding-content-.html
+                      include_versions:
+                        - '202005.0'
+                    - title: References
+                      nested:
+                        - title: Content Item Widgets templates- Reference
+                            Information
+                          url: /docs/scos/dev/user-guides/back-office-user-guide/content/content-items/references/content-item-wi.html
+                          include_versions:
+                            - '202005.0'
+                        - title: Content Items- Reference Information
+                          url: /docs/scos/dev/user-guides/back-office-user-guide/content/content-items/references/content-items-r.html
+                          include_versions:
+                            - '202005.0'
+                        - title: Reference information- content Item widgets
+                            templates
+                          url: /docs/scos/dev/user-guides/back-office-user-guide/content/content-items/references/content-item-wi.html
+                          include_versions:
+                            - '202009.0'
+                            - '202108.0'
+                        - title: Reference information- content items
+                          url: /docs/scos/dev/user-guides/back-office-user-guide/content/content-items/references/content-items-r.html
+                          include_versions:
+                            - '202009.0'
+                            - '202108.0'
+                    - title: Editing Content Items in CMS Pages and Blocks
+                      url: /docs/scos/dev/user-guides/back-office-user-guide/content/content-items/editing-content.html
+                      include_versions:
+                        - '202005.0'
+                    - title: Creating Content Items
+                      url: /docs/scos/dev/user-guides/back-office-user-guide/content/content-items/creating-conten.html
+                      include_versions:
+                        - '202005.0'
+                    - title: Adding content items to CMS pages and blocks
+                      url: /docs/scos/dev/user-guides/back-office-user-guide/content/content-items/adding-content-.html
+                      include_versions:
+                        - '202009.0'
+                        - '202108.0'
+                    - title: Editing content items in CMS pages and blocks
+                      url: /docs/scos/dev/user-guides/back-office-user-guide/content/content-items/editing-content.html
+                      include_versions:
+                        - '202009.0'
+                        - '202108.0'
+                    - title: Creating content items
+                      url: /docs/scos/dev/user-guides/back-office-user-guide/content/content-items/creating-conten.html
+                      include_versions:
+                        - '202009.0'
+                        - '202108.0'
+                - title: Content
+                  url: /docs/scos/dev/user-guides/back-office-user-guide/content/content.html
+                  include_versions:
+                    - '202005.0'
+                - title: Navigation
+                  nested:
+                    - title: References
+                      nested:
+                        - title: Navigation- Reference Information
+                          url: /docs/scos/dev/user-guides/back-office-user-guide/content/navigation/references/navigation-refe.html
+                          include_versions:
+                            - '202005.0'
+                        - title: Reference information- navigation
+                          url: /docs/scos/dev/user-guides/back-office-user-guide/content/navigation/references/navigation-refe.html
+                          include_versions:
+                            - '202009.0'
+                    - title: Managing Navigation Elements
+                      url: /docs/scos/dev/user-guides/back-office-user-guide/content/navigation/managing-naviga.html
+                      include_versions:
+                        - '202005.0'
+                    - title: Navigation
+                      url: /docs/scos/dev/user-guides/back-office-user-guide/content/navigation/navigation-guid.html
+                      include_versions:
+                        - '202005.0'
+                    - title: Managing navigation elements
+                      url: /docs/scos/dev/user-guides/back-office-user-guide/content/navigation/managing-naviga.html
+                      include_versions:
+                        - '202009.0'
+                        - '202108.0'
+                - title: Redirects
+                  nested:
+                    - title: Redirects
+                      url: /docs/scos/dev/user-guides/back-office-user-guide/content/redirects/redirects.html
+                      include_versions:
+                        - '202005.0'
+                    - title: References
+                      nested:
+                        - title: CMS Redirects- References
+                          url: /docs/scos/dev/user-guides/back-office-user-guide/content/redirects/references/cms-redirects-r.html
+                          include_versions:
+                            - '202005.0'
+                        - title: Reference Information- CMS redirects
+                          url: /docs/scos/dev/user-guides/back-office-user-guide/content/redirects/references/cms-redirects-r.html
+                          include_versions:
+                            - '202009.0'
+                    - title: Creating CMS Redirects
+                      url: /docs/scos/dev/user-guides/back-office-user-guide/content/redirects/creating-cms-re.html
+                      include_versions:
+                        - '202005.0'
+                        - '202009.0'
+                    - title: Managing CMS Redirects
+                      url: /docs/scos/dev/user-guides/back-office-user-guide/content/redirects/editing-cms-red.html
+                      include_versions:
+                        - '202005.0'
+                    - title: Managing CMS redirects
+                      url: /docs/scos/dev/user-guides/back-office-user-guide/content/redirects/managing-cms-re.html
+                      include_versions:
+                        - '202009.0'
+                        - '202108.0'
+                    - title: Creating CMS redirects
+                      url: /docs/scos/dev/user-guides/back-office-user-guide/content/redirects/creating-cms-re.html
+                      include_versions:
+                        - '202108.0'
+                - title: File Manager
+                  nested:
+                    - title: File Manager
+                      url: /docs/scos/dev/user-guides/back-office-user-guide/content/file-manager/file-manager.html
+                      include_versions:
+                        - '202005.0'
+                    - title: Managing File Tree
+                      url: /docs/scos/dev/user-guides/back-office-user-guide/content/file-manager/managing-file-t.html
+                      include_versions:
+                        - '202005.0'
+                    - title: Managing File List
+                      url: /docs/scos/dev/user-guides/back-office-user-guide/content/file-manager/managing-file-l.html
+                      include_versions:
+                        - '202005.0'
+                    - title: Managing file tree
+                      url: /docs/scos/dev/user-guides/back-office-user-guide/content/file-manager/managing-file-t.html
+                      include_versions:
+                        - '202009.0'
+                        - '202108.0'
+                    - title: Managing file list
+                      url: /docs/scos/dev/user-guides/back-office-user-guide/content/file-manager/managing-file-l.html
+                      include_versions:
+                        - '202009.0'
+                        - '202108.0'
+                - title: Pages
+                  nested:
+                    - title: References
+                      nested:
+                        - title: CMS Pages- Reference Information
+                          url: /docs/scos/dev/user-guides/back-office-user-guide/content/pages/references/cms-pages-refer.html
+                          include_versions:
+                            - '202005.0'
+                        - title: Reference information- CMS pages
+                          url: /docs/scos/dev/user-guides/back-office-user-guide/content/pages/references/cms-pages-refer.html
+                          include_versions:
+                            - '202009.0'
+                    - title: Managing CMS Pages
+                      url: /docs/scos/dev/user-guides/back-office-user-guide/content/pages/managing-cms-pa.html
+                      include_versions:
+                        - '202005.0'
+                    - title: CMS Pages
+                      url: /docs/scos/dev/user-guides/back-office-user-guide/content/pages/cms-pages.html
+                      include_versions:
+                        - '202005.0'
+                    - title: Editing CMS Pages
+                      url: /docs/scos/dev/user-guides/back-office-user-guide/content/pages/editing-cms-pag.html
+                      include_versions:
+                        - '202005.0'
+                    - title: Creating a CMS Page
+                      url: /docs/scos/dev/user-guides/back-office-user-guide/content/pages/creating-a-cms-.html
+                      include_versions:
+                        - '202005.0'
+                    - title: CMS Pages Versioning
+                      url: /docs/scos/dev/user-guides/back-office-user-guide/content/pages/cms-pages-versi.html
+                      include_versions:
+                        - '202005.0'
+                    - title: Managing CMS pages
+                      url: /docs/scos/dev/user-guides/back-office-user-guide/content/pages/managing-cms-pa.html
+                      include_versions:
+                        - '202009.0'
+                        - '202108.0'
+                    - title: Editing CMS pages
+                      url: /docs/scos/dev/user-guides/back-office-user-guide/content/pages/editing-cms-pag.html
+                      include_versions:
+                        - '202009.0'
+                        - '202108.0'
+                    - title: Creating a CMS page
+                      url: /docs/scos/dev/user-guides/back-office-user-guide/content/pages/creating-a-cms-.html
+                      include_versions:
+                        - '202009.0'
+                        - '202108.0'
+                - title: Slots
+                  nested:
+                    - title: References
+                      nested:
+                        - title: Slots- Reference Information
+                          url: /docs/scos/dev/user-guides/back-office-user-guide/content/slots/references/slots-reference.html
+                          include_versions:
+                            - '202005.0'
+                        - title: Reference information- slots
+                          url: /docs/scos/dev/user-guides/back-office-user-guide/content/slots/references/slots-reference.html
+                          include_versions:
+                            - '202009.0'
+                    - title: Managing Slots
+                      url: /docs/scos/dev/user-guides/back-office-user-guide/content/slots/managing-slots.html
+                      include_versions:
+                        - '202005.0'
+                    - title: Slots
+                      url: /docs/scos/dev/user-guides/back-office-user-guide/content/slots/slots.html
+                      include_versions:
+                        - '202005.0'
+                    - title: Managing slots
+                      url: /docs/scos/dev/user-guides/back-office-user-guide/content/slots/managing-slots.html
+                      include_versions:
+                        - '202009.0'
+                        - '202108.0'
+                - title: Adding content to storefront pages using templates & slots-
+                    Best practices
+                  url: /docs/scos/dev/user-guides/back-office-user-guide/content/adding-content-.html
+                  include_versions:
+                    - '202009.0'
+                    - '202108.0'
+            - title: Users
+              nested:
+                - title: 'Roles, groups and users'
+                  nested:
+                    - title: References
+                      nested:
+                        - title: Roles- Reference Information
+                          url: /docs/scos/dev/user-guides/back-office-user-guide/users/roles-groups-and-users/references/roles-reference.html
+                          include_versions:
+                            - '202005.0'
+                        - title: User- Reference Information
+                          url: /docs/scos/dev/user-guides/back-office-user-guide/users/roles-groups-and-users/references/user-reference-.html
+                          include_versions:
+                            - '202005.0'
+                        - title: Reference information- Roles
+                          url: /docs/scos/dev/user-guides/back-office-user-guide/users/roles-groups-and-users/references/roles-reference.html
+                          include_versions:
+                            - '202009.0'
+                            - '202108.0'
+                        - title: Reference information- User
+                          url: /docs/scos/dev/user-guides/back-office-user-guide/users/roles-groups-and-users/references/user-reference-.html
+                          include_versions:
+                            - '202009.0'
+                            - '202108.0'
+                    - title: Managing Roles
+                      url: /docs/scos/dev/user-guides/back-office-user-guide/users/roles-groups-and-users/managing-roles.html
+                      include_versions:
+                        - '202005.0'
+                    - title: Managing Users
+                      url: /docs/scos/dev/user-guides/back-office-user-guide/users/roles-groups-and-users/managing-users.html
+                      include_versions:
+                        - '202005.0'
+                    - title: Managing Groups
+                      url: /docs/scos/dev/user-guides/back-office-user-guide/users/roles-groups-and-users/managing-groups.html
+                      include_versions:
+                        - '202005.0'
+                    - title: Managing roles
+                      url: /docs/scos/dev/user-guides/back-office-user-guide/users/roles-groups-and-users/managing-roles.html
+                      include_versions:
+                        - '202009.0'
+                        - '202108.0'
+                    - title: Managing users
+                      url: /docs/scos/dev/user-guides/back-office-user-guide/users/roles-groups-and-users/managing-users.html
+                      include_versions:
+                        - '202009.0'
+                        - '202108.0'
+                    - title: Managing groups
+                      url: /docs/scos/dev/user-guides/back-office-user-guide/users/roles-groups-and-users/managing-groups.html
+                      include_versions:
+                        - '202009.0'
+                        - '202108.0'
+                - title: Users
+                  url: /docs/scos/dev/user-guides/back-office-user-guide/users/users.html
+                  include_versions:
+                    - '202005.0'
+            - title: Merchandising
+              nested:
+                - title: Configurable bundle templates
+                  nested:
+                    - title: References
+                      nested:
+                        - title: Configurable Bundle Templates- Reference Information
+                          url: /docs/scos/dev/user-guides/back-office-user-guide/merchandising/configurable-bundle-templates/references/configurable-bu.html
+                          include_versions:
+                            - '202005.0'
+                        - title: Reference information- Configurable bundle templates
+                          url: /docs/scos/dev/user-guides/back-office-user-guide/merchandising/configurable-bundle-templates/references/configurable-bu.html
+                          include_versions:
+                            - '202009.0'
+                    - title: Managing Configurable Bundle Templates
+                      url: /docs/scos/dev/user-guides/back-office-user-guide/merchandising/configurable-bundle-templates/managing-config.html
+                      include_versions:
+                        - '202005.0'
+                    - title: Creating Configurable Bundle Templates
+                      url: /docs/scos/dev/user-guides/back-office-user-guide/merchandising/configurable-bundle-templates/creating-config.html
+                      include_versions:
+                        - '202005.0'
+                    - title: Configurable Bundle Templates
+                      url: /docs/scos/dev/user-guides/back-office-user-guide/merchandising/configurable-bundle-templates/configurable-bu.html
+                      include_versions:
+                        - '202005.0'
+                    - title: Managing configurable bundle templates
+                      url: /docs/scos/dev/user-guides/back-office-user-guide/merchandising/configurable-bundle-templates/managing-config.html
+                      include_versions:
+                        - '202009.0'
+                        - '202108.0'
+                    - title: Creating configurable bundle templates
+                      url: /docs/scos/dev/user-guides/back-office-user-guide/merchandising/configurable-bundle-templates/creating-config.html
+                      include_versions:
+                        - '202009.0'
+                        - '202108.0'
+                - title: Discount
+                  nested:
+                    - title: References
+                      nested:
+                        - title: Discount Conditions- Reference Information
+                          url: /docs/scos/dev/user-guides/back-office-user-guide/merchandising/discount/references/discount-condit.html
+                          include_versions:
+                            - '202005.0'
+                        - title: Discount- Reference Information
+                          url: /docs/scos/dev/user-guides/back-office-user-guide/merchandising/discount/references/discount-refere.html
+                          include_versions:
+                            - '202005.0'
+                        - title: Voucher Codes- Reference Information
+                          url: /docs/scos/dev/user-guides/back-office-user-guide/merchandising/discount/references/voucher-codes-r.html
+                          include_versions:
+                            - '202005.0'
+                        - title: Discount Calculation- Reference Information
+                          url: /docs/scos/dev/user-guides/back-office-user-guide/merchandising/discount/references/discount-calcul.html
+                          include_versions:
+                            - '202005.0'
+                        - title: Token Description Tables
+                          url: /docs/scos/dev/user-guides/back-office-user-guide/merchandising/discount/references/token-descripti.html
+                          include_versions:
+                            - '202005.0'
+                        - title: Reference information- discount conditions
+                          url: /docs/scos/dev/user-guides/back-office-user-guide/merchandising/discount/references/discount-condit.html
+                          include_versions:
+                            - '202009.0'
+                        - title: Reference information- discount
+                          url: /docs/scos/dev/user-guides/back-office-user-guide/merchandising/discount/references/discount-refere.html
+                          include_versions:
+                            - '202009.0'
+                        - title: Reference information- voucher codes
+                          url: /docs/scos/dev/user-guides/back-office-user-guide/merchandising/discount/references/voucher-codes-r.html
+                          include_versions:
+                            - '202009.0'
+                        - title: Reference information- discount calculation
+                          url: /docs/scos/dev/user-guides/back-office-user-guide/merchandising/discount/references/discount-calcul.html
+                          include_versions:
+                            - '202009.0'
+                        - title: Token description tables
+                          url: /docs/scos/dev/user-guides/back-office-user-guide/merchandising/discount/references/token-descripti.html
+                          include_versions:
+                            - '202009.0'
+                    - title: Creating a Discount
+                      nested:
+                        - title: Creating a Cart Rule
+                          url: /docs/scos/dev/user-guides/back-office-user-guide/merchandising/discount/creating-a-discount/creating-a-cart.html
+                          include_versions:
+                            - '202005.0'
+                        - title: Creating a Voucher
+                          url: /docs/scos/dev/user-guides/back-office-user-guide/merchandising/discount/creating-a-discount/creating-a-vouc.html
+                          include_versions:
+                            - '202005.0'
+                    - title: Discount
+                      url: /docs/scos/dev/user-guides/back-office-user-guide/merchandising/discount/discount-1.html
+                      include_versions:
+                        - '202005.0'
+                    - title: Managing Discounts
+                      url: /docs/scos/dev/user-guides/back-office-user-guide/merchandising/discount/managing-discou.html
+                      include_versions:
+                        - '202005.0'
+                    - title: Creating a cart rule
+                      url: /docs/scos/dev/user-guides/back-office-user-guide/merchandising/discount/creating-a-cart.html
+                      include_versions:
+                        - '202009.0'
+                        - '202108.0'
+                    - title: Creating a voucher
+                      url: /docs/scos/dev/user-guides/back-office-user-guide/merchandising/discount/creating-a-vouc.html
+                      include_versions:
+                        - '202009.0'
+                        - '202108.0'
+                    - title: Managing discounts
+                      url: /docs/scos/dev/user-guides/back-office-user-guide/merchandising/discount/managing-discou.html
+                      include_versions:
+                        - '202009.0'
+                        - '202108.0'
+                - title: Product relations
+                  nested:
+                    - title: References
+                      nested:
+                        - title: Product Relations- Reference Information
+                          url: /docs/scos/dev/user-guides/back-office-user-guide/merchandising/product-relations/references/product-relatio.html
+                          include_versions:
+                            - '202005.0'
+                        - title: Reference information- product relations
+                          url: /docs/scos/dev/user-guides/back-office-user-guide/merchandising/product-relations/references/product-relatio.html
+                          include_versions:
+                            - '202009.0'
+                    - title: Creating a Product Relation
+                      url: /docs/scos/dev/user-guides/back-office-user-guide/merchandising/product-relations/creating-a-prod.html
+                      include_versions:
+                        - '202005.0'
+                    - title: Managing Product Relations
+                      url: /docs/scos/dev/user-guides/back-office-user-guide/merchandising/product-relations/managing-produc.html
+                      include_versions:
+                        - '202005.0'
+                    - title: Product Relations
+                      url: /docs/scos/dev/user-guides/back-office-user-guide/merchandising/product-relations/product-relatio.html
+                      include_versions:
+                        - '202005.0'
+                    - title: Managing product relations
+                      url: /docs/scos/dev/user-guides/back-office-user-guide/merchandising/product-relations/managing-produc.html
+                      include_versions:
+                        - '202009.0'
+                        - '202108.0'
+                    - title: Creating product relations
+                      url: /docs/scos/dev/user-guides/back-office-user-guide/merchandising/product-relations/creating-produc.html
+                      include_versions:
+                        - '202108.0'
+                    - title: Creating a product relation
+                      url: /docs/scos/dev/user-guides/back-office-user-guide/merchandising/product-relations/creating-a-prod.html
+                      include_versions:
+                        - '202009.0'
+                - title: Product labels
+                  nested:
+                    - title: Product Labels
+                      url: /docs/scos/dev/user-guides/back-office-user-guide/merchandising/product-labels/product-labels.html
+                      include_versions:
+                        - '202005.0'
+                    - title: References
+                      nested:
+                        - title: Product Labels- Reference Information
+                          url: /docs/scos/dev/user-guides/back-office-user-guide/merchandising/product-labels/references/product-labels-.html
+                          include_versions:
+                            - '202005.0'
+                        - title: Reference information- product labels
+                          url: /docs/scos/dev/user-guides/back-office-user-guide/merchandising/product-labels/references/product-labels-.html
+                          include_versions:
+                            - '202009.0'
+                    - title: Creating a Product Label
+                      url: /docs/scos/dev/user-guides/back-office-user-guide/merchandising/product-labels/creating-a-prod.html
+                      include_versions:
+                        - '202005.0'
+                    - title: Managing Product Labels
+                      url: /docs/scos/dev/user-guides/back-office-user-guide/merchandising/product-labels/managing-produc.html
+                      include_versions:
+                        - '202005.0'
+                    - title: Prioritizing Labels
+                      url: /docs/scos/dev/user-guides/back-office-user-guide/merchandising/product-labels/prioritizing-la.html
+                      include_versions:
+                        - '202005.0'
+                    - title: Managing product labels
+                      url: /docs/scos/dev/user-guides/back-office-user-guide/merchandising/product-labels/managing-produc.html
+                      include_versions:
+                        - '202009.0'
+                        - '202108.0'
+                    - title: Creating product labels
+                      url: /docs/scos/dev/user-guides/back-office-user-guide/merchandising/product-labels/creating-produc.html
+                      include_versions:
+                        - '202009.0'
+                        - '202108.0'
+                - title: Search and filters
+                  nested:
+                    - title: Managing Category Filters
+                      url: /docs/scos/dev/user-guides/back-office-user-guide/merchandising/search-and-filters/managing-catego.html
+                      include_versions:
+                        - '202005.0'
+                    - title: References
+                      nested:
+                        - title: Reference- Search Preferences
+                          url: /docs/scos/dev/user-guides/back-office-user-guide/merchandising/search-and-filters/references/reference-searc.html
+                          include_versions:
+                            - '202005.0'
+                        - title: Search Preferences Types
+                          url: /docs/scos/dev/user-guides/back-office-user-guide/merchandising/search-and-filters/references/search-preferen.html
+                          include_versions:
+                            - '202005.0'
+                        - title: Reference information- Search preferences
+                          url: /docs/scos/dev/user-guides/back-office-user-guide/merchandising/search-and-filters/references/reference-searc.html
+                          include_versions:
+                            - '202009.0'
+                            - '202108.0'
+                        - title: Reference information- Search preferences types
+                          url: /docs/scos/dev/user-guides/back-office-user-guide/merchandising/search-and-filters/references/search-preferen.html
+                          include_versions:
+                            - '202009.0'
+                            - '202108.0'
+                    - title: Managing Search Preferences
+                      url: /docs/scos/dev/user-guides/back-office-user-guide/merchandising/search-and-filters/managing-search.html
+                      include_versions:
+                        - '202005.0'
+                    - title: Managing Filter Preferences
+                      url: /docs/scos/dev/user-guides/back-office-user-guide/merchandising/search-and-filters/managing-filter.html
+                      include_versions:
+                        - '202005.0'
+                    - title: Search and Filters
+                      url: /docs/scos/dev/user-guides/back-office-user-guide/merchandising/search-and-filters/search-and-filt.html
+                      include_versions:
+                        - '202005.0'
+                    - title: Managing category filters
+                      url: /docs/scos/dev/user-guides/back-office-user-guide/merchandising/search-and-filters/managing-catego.html
+                      include_versions:
+                        - '202009.0'
+                        - '202108.0'
+                    - title: Managing search preferences
+                      url: /docs/scos/dev/user-guides/back-office-user-guide/merchandising/search-and-filters/managing-search.html
+                      include_versions:
+                        - '202009.0'
+                        - '202108.0'
+                    - title: Managing filter preferences
+                      url: /docs/scos/dev/user-guides/back-office-user-guide/merchandising/search-and-filters/managing-filter.html
+                      include_versions:
+                        - '202009.0'
+                        - '202108.0'
+                - title: Product sets
+                  nested:
+                    - title: References
+                      nested:
+                        - title: Product Sets- Reference Information
+                          url: /docs/scos/dev/user-guides/back-office-user-guide/merchandising/product-sets/references/product-sets-re.html
+                          include_versions:
+                            - '202005.0'
+                        - title: Reference information- Product sets
+                          url: /docs/scos/dev/user-guides/back-office-user-guide/merchandising/product-sets/references/product-sets-re.html
+                          include_versions:
+                            - '202009.0'
+                    - title: Creating a Product Set
+                      url: /docs/scos/dev/user-guides/back-office-user-guide/merchandising/product-sets/creating-a-prod.html
+                      include_versions:
+                        - '202005.0'
+                    - title: Product Sets
+                      url: /docs/scos/dev/user-guides/back-office-user-guide/merchandising/product-sets/product-sets.html
+                      include_versions:
+                        - '202005.0'
+                    - title: Managing Product Sets
+                      url: /docs/scos/dev/user-guides/back-office-user-guide/merchandising/product-sets/managing-produc.html
+                      include_versions:
+                        - '202005.0'
+                    - title: Managing product sets
+                      url: /docs/scos/dev/user-guides/back-office-user-guide/merchandising/product-sets/managing-produc.html
+                      include_versions:
+                        - '202009.0'
+                        - '202108.0'
+                    - title: Creating product sets
+                      url: /docs/scos/dev/user-guides/back-office-user-guide/merchandising/product-sets/creating-produc.html
+                      include_versions:
+                        - '202009.0'
+                        - '202108.0'
+            - title: Customer
+              nested:
+                - title: 'Customer, customer access, customer groups'
+                  nested:
+                    - title: References
+                      nested:
+                        - title: Customers- Reference Information
+                          url: /docs/scos/dev/user-guides/back-office-user-guide/customer/customer-customer-access-customer-groups/references/customers-refer.html
+                          include_versions:
+                            - '202005.0'
+                        - title: Reference information- customers
+                          url: /docs/scos/dev/user-guides/back-office-user-guide/customer/customer-customer-access-customer-groups/references/customers-refer.html
+                          include_versions:
+                            - '202009.0'
+                            - '202108.0'
+                    - title: Managing Customer Addresses
+                      url: /docs/scos/dev/user-guides/back-office-user-guide/customer/customer-customer-access-customer-groups/managing-custom.html
+                      include_versions:
+                        - '202005.0'
+                    - title: Managing customer addresses
+                      url: /docs/scos/dev/user-guides/back-office-user-guide/customer/customer-customer-access-customer-groups/managing-custom.html
+                      include_versions:
+                        - '202009.0'
+                        - '202108.0'
+                - title: Customer
+                  url: /docs/scos/dev/user-guides/back-office-user-guide/customer/customer.html
+                  include_versions:
+                    - '202005.0'
+                - title: Company account
+                  nested:
+                    - title: Company Account
+                      url: /docs/scos/dev/user-guides/back-office-user-guide/customer/company-account/company-account.html
+                      include_versions:
+                        - '202005.0'
+                    - title: References
+                      nested:
+                        - title: Company Account- Reference Information
+                          url: /docs/scos/dev/user-guides/back-office-user-guide/customer/company-account/references/company-account.html
+                          include_versions:
+                            - '202005.0'
+                        - title: Reference information- Company account
+                          url: /docs/scos/dev/user-guides/back-office-user-guide/customer/company-account/references/company-account.html
+                          include_versions:
+                            - '202009.0'
+                            - '202108.0'
+                    - title: Managing a Company Account
+                      nested:
+                        - title: Managing Companies
+                          url: /docs/scos/dev/user-guides/back-office-user-guide/customer/company-account/managing-a-company-account/managing-compan.html
+                          include_versions:
+                            - '202005.0'
+                    - title: Managing companies
+                      url: /docs/scos/dev/user-guides/back-office-user-guide/customer/company-account/managing-compan.html
+                      include_versions:
+                        - '202009.0'
+                        - '202108.0'
+            - title: Overview of the Back Office user guide
+              url: /docs/scos/dev/user-guides/back-office-user-guide/overview-of-the.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+            - title: Logging in to the Back Office
+              url: /docs/scos/dev/user-guides/back-office-user-guide/logging-in-to-t.html
+              include_versions:
+                - '202108.0'
+            - title: About the Back Office Guide
+              url: /docs/scos/dev/user-guides/back-office-user-guide/about-the-back-.html
+              include_versions:
+                - '201907.0'
+            - title: Shipment
+              nested:
+                - title: Shipment
+                  url: /docs/scos/dev/user-guides/back-office-user-guide/shipment/shipment-manage.html
+                  include_versions:
+                    - '201907.0'
+                - title: Creating a Carrier Company
+                  url: /docs/scos/dev/user-guides/back-office-user-guide/shipment/creating-a-carr.html
+                  include_versions:
+                    - '201907.0'
+                - title: Creating and Managing Shipment Methods
+                  url: /docs/scos/dev/user-guides/back-office-user-guide/shipment/creating-and-ma.html
+                  include_versions:
+                    - '201907.0'
+        - title: Shop user guide
+          nested:
+            - title: Shop Guide - Company Users
+              url: /docs/scos/dev/user-guides/shop-user-guide/company-users-s.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+                - '201907.0'
+                - '202001.0'
+                - '202005.0'
+            - title: Shop Guide - Shopping Lists
+              url: /docs/scos/dev/user-guides/shop-user-guide/shopping-lists-.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+                - '201907.0'
+                - '202001.0'
+            - title: Shop Guide - Agent Account
+              nested:
+                - title: Shop Guide - Managing Agent Account
+                  url: /docs/scos/dev/user-guides/shop-user-guide/shop-guide-agent-account/shop-guide-mana.html
+                  include_versions:
+                    - '202001.0'
+                    - '202005.0'
+                - title: Shop Guide - Agent Account
+                  url: /docs/scos/dev/user-guides/shop-user-guide/shop-guide-agent-account/shop-guide-agen.html
+                  include_versions:
+                    - '202001.0'
+                    - '202005.0'
+            - title: Shop Guide - Company Account
+              url: /docs/scos/dev/user-guides/shop-user-guide/company-account.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+                - '201907.0'
+                - '202001.0'
+                - '202005.0'
+            - title: Shop Guide - Quick Order
+              url: /docs/scos/dev/user-guides/shop-user-guide/quick-order-sho.html
+              include_versions:
+                - '201903.0'
+                - '201907.0'
+                - '202001.0'
+                - '202005.0'
+            - title: About Shop User Guide
+              url: /docs/scos/dev/user-guides/shop-user-guide/about-shop-user.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+                - '201907.0'
+                - '202001.0'
+                - '202005.0'
+            - title: Shop Guide - Wishlists
+              url: /docs/scos/dev/user-guides/shop-user-guide/shop-guide-wish.html
+              include_versions:
+                - '202001.0'
+            - title: Shop Guide - Searching within CMS Pages
+              url: /docs/scos/dev/user-guides/shop-user-guide/searching-withi.html
+              include_versions:
+                - '202001.0'
+                - '202005.0'
+            - title: Shop Guide - Company Roles
+              url: /docs/scos/dev/user-guides/shop-user-guide/company-roles-s.html
+              include_versions:
+                - '201811.0'
+                - '201903.0'
+                - '201907.0'
+                - '202001.0'
+            - title: Shop Guide - Shopping Carts
+              nested:
+                - title: Shopping Carts- Reference Information
+                  url: /docs/scos/dev/user-guides/shop-user-guide/shop-guide-shopping-carts/shop-guide-shop.html
+                  include_versions:
+                    - '202001.0'
+                - title: Shop Guide - Creating a Shopping Cart
+                  url: /docs/scos/dev/user-guides/shop-user-guide/shop-guide-shopping-carts/creating-shoppi.html
+                  include_versions:
+                    - '202001.0'
+                - title: Shop Guide - Managing Shopping Carts
+                  url: /docs/scos/dev/user-guides/shop-user-guide/shop-guide-shopping-carts/shop-guide-mana.html
+                  include_versions:
+                    - '202001.0'
+            - title: Shop Guide - Comments
+              nested:
+                - title: Shop Guide - Comments
+                  url: /docs/scos/dev/user-guides/shop-user-guide/shop-guide-comments/comments-shop-g.html
+                  include_versions:
+                    - '202001.0'
+                    - '202005.0'
+                - title: Shop Guide - Managing Comments
+                  url: /docs/scos/dev/user-guides/shop-user-guide/shop-guide-comments/managing-commen.html
+                  include_versions:
+                    - '202001.0'
+                    - '202005.0'
+            - title: Shop Guide -  Quotation Process & RFQ
+              nested:
+                - title: Shop Guide - Request for Quote- Reference Information
+                  url: /docs/scos/dev/user-guides/shop-user-guide/shop-guide-quotation-process-and-rfq/rfq-reference-i.html
+                  include_versions:
+                    - '202001.0'
+                - title: Shop Guide - Request for Quote
+                  url: /docs/scos/dev/user-guides/shop-user-guide/shop-guide-quotation-process-and-rfq/request-for-quo.html
+                  include_versions:
+                    - '202001.0'
+                - title: Shop Guide - Managing Requests for Quotes for a Sales
+                    Representative
+                  url: /docs/scos/dev/user-guides/shop-user-guide/shop-guide-quotation-process-and-rfq/managing-rfqs-s.html
+                  include_versions:
+                    - '202001.0'
+                - title: Shop Guide - Creating a Request for Quote
+                  url: /docs/scos/dev/user-guides/shop-user-guide/shop-guide-quotation-process-and-rfq/creating-rfq-sh.html
+                  include_versions:
+                    - '202001.0'
+                - title: Shop Guide - Managing Requests for Quotes for a Buyer
+                  url: /docs/scos/dev/user-guides/shop-user-guide/shop-guide-quotation-process-and-rfq/managing-rfqs-f.html
+                  include_versions:
+                    - '202001.0'
+            - title: Shop guide - Configurator
+              nested:
+                - title: Shop Guide - Configurator
+                  url: /docs/scos/dev/user-guides/shop-user-guide/shop-guide-configurator/shop-guide-conf.html
+                  include_versions:
+                    - '202001.0'
+                    - '202005.0'
+                - title: Shop Guide - Managing Configurable Bundles
+                  url: /docs/scos/dev/user-guides/shop-user-guide/shop-guide-configurator/shop-guide-mana.html
+                  include_versions:
+                    - '202001.0'
+                    - '202005.0'
+                - title: Shop guide - Configurator
+                  url: /docs/scos/dev/user-guides/shop-user-guide/shop-guide-configurator/shop-guide-conf.html
+                  include_versions:
+                    - '202009.0'
+                    - '202108.0'
+                - title: Shop guide - Managing configurable bundles
+                  url: /docs/scos/dev/user-guides/shop-user-guide/shop-guide-configurator/shop-guide-mana.html
+                  include_versions:
+                    - '202009.0'
+                    - '202108.0'
+            - title: Shop Guide - Approval Process
+              url: /docs/scos/dev/user-guides/shop-user-guide/approval-proces.html
+              include_versions:
+                - '201903.0'
+                - '201907.0'
+                - '202001.0'
+                - '202005.0'
+            - title: Shop Guide - Business on Behalf
+              url: /docs/scos/dev/user-guides/shop-user-guide/business-on-beh.html
+              include_versions:
+                - '201903.0'
+                - '201907.0'
+                - '202001.0'
+                - '202005.0'
+            - title: Shop Guide - Managing Products
+              url: /docs/scos/dev/user-guides/shop-user-guide/shop-guide-mana.html
+              include_versions:
+                - '202001.0'
+                - '202005.0'
+            - title: Shop Guide - Checkout
+              nested:
+                - title: Shop Guide - Shipment Step
+                  url: /docs/scos/dev/user-guides/shop-user-guide/shop-guide-checkout/shipment-step-s.html
+                  include_versions:
+                    - '202001.0'
+                    - '202005.0'
+                - title: Shop Guide - Payment Step
+                  url: /docs/scos/dev/user-guides/shop-user-guide/shop-guide-checkout/payment-step-sh.html
+                  include_versions:
+                    - '202001.0'
+                    - '202005.0'
+                - title: Shop Guide - Summary Step
+                  url: /docs/scos/dev/user-guides/shop-user-guide/shop-guide-checkout/summary-step-sh.html
+                  include_versions:
+                    - '202001.0'
+                    - '202005.0'
+                - title: Shop Guide - Checkout
+                  url: /docs/scos/dev/user-guides/shop-user-guide/shop-guide-checkout/checkout-shop-g.html
+                  include_versions:
+                    - '202001.0'
+                    - '202005.0'
+                - title: Shop Guide - Address Step
+                  url: /docs/scos/dev/user-guides/shop-user-guide/shop-guide-checkout/address-step-sh.html
+                  include_versions:
+                    - '202001.0'
+                    - '202005.0'
+                - title: Shop Guide - Login Step
+                  url: /docs/scos/dev/user-guides/shop-user-guide/shop-guide-checkout/shop-guide-logi.html
+                  include_versions:
+                    - '202005.0'
+            - title: Shop Application Guide
+              nested:
+                - title: Cart
+                  nested:
+                    - title: Multiple Carts per User Feature Overview
+                      url: /docs/scos/dev/user-guides/shop-user-guide/shop-application-guide/cart/multiple-carts-.html
+                      include_versions:
+                        - '201811.0'
+                        - '201903.0'
+                        - '201907.0'
+                    - title: Shared Cart Feature Overview
+                      url: /docs/scos/dev/user-guides/shop-user-guide/shop-application-guide/cart/shared-cart-fea.html
+                      include_versions:
+                        - '201811.0'
+                        - '201903.0'
+                        - '201907.0'
+                    - title: Minimum Order Value Feature Overview
+                      url: /docs/scos/dev/user-guides/shop-user-guide/shop-application-guide/cart/minimum-order-v.html
+                      include_versions:
+                        - '201811.0'
+                        - '201903.0'
+                        - '201907.0'
+                    - title: Shopping Cart Widget Feature Overview
+                      url: /docs/scos/dev/user-guides/shop-user-guide/shop-application-guide/cart/shopping-cart-w.html
+                      include_versions:
+                        - '201811.0'
+                        - '201903.0'
+                        - '201907.0'
+            - title: Checkout
+              nested:
+                - title: Shop Guide - Shipment Step
+                  url: /docs/scos/dev/user-guides/shop-user-guide/checkout/shipment-step-s.html
+                  include_versions:
+                    - '201811.0'
+                    - '201903.0'
+                    - '201907.0'
+                - title: Shop Guide - Payment Step
+                  url: /docs/scos/dev/user-guides/shop-user-guide/checkout/payment-step-sh.html
+                  include_versions:
+                    - '201811.0'
+                    - '201903.0'
+                    - '201907.0'
+                - title: Shop Guide - Summary Step
+                  url: /docs/scos/dev/user-guides/shop-user-guide/checkout/summary-step-sh.html
+                  include_versions:
+                    - '201811.0'
+                    - '201903.0'
+                    - '201907.0'
+                - title: Shop Guide - Checkout
+                  url: /docs/scos/dev/user-guides/shop-user-guide/checkout/checkout-shop-g.html
+                  include_versions:
+                    - '201811.0'
+                    - '201903.0'
+                    - '201907.0'
+                - title: Shop Guide - Address Step
+                  url: /docs/scos/dev/user-guides/shop-user-guide/checkout/address-step-sh.html
+                  include_versions:
+                    - '201811.0'
+                    - '201903.0'
+                    - '201907.0'
+            - title: Shop guide - Customer account
+              nested:
+                - title: Shop Guide - Shopping Lists
+                  url: /docs/scos/dev/user-guides/shop-user-guide/shop-guide-customer-account/shopping-lists-.html
+                  include_versions:
+                    - '202005.0'
+                - title: References
+                  nested:
+                    - title: Request for Quote- Reference Information
+                      url: /docs/scos/dev/user-guides/shop-user-guide/shop-guide-customer-account/references/rfq-reference-i.html
+                      include_versions:
+                        - '202005.0'
+                    - title: Addresses- Reference Information
+                      url: /docs/scos/dev/user-guides/shop-user-guide/shop-guide-customer-account/references/addresses-refer.html
+                      include_versions:
+                        - '202005.0'
+                    - title: Shopping Carts- Reference Information
+                      url: /docs/scos/dev/user-guides/shop-user-guide/shop-guide-customer-account/references/shop-guide-shop.html
+                      include_versions:
+                        - '202005.0'
+                    - title: Order History- Reference Information
+                      url: /docs/scos/dev/user-guides/shop-user-guide/shop-guide-customer-account/references/order-history-r.html
+                      include_versions:
+                        - '202005.0'
+                    - title: Return Details- Reference Information
+                      url: /docs/scos/dev/user-guides/shop-user-guide/shop-guide-customer-account/references/return-details-.html
+                      include_versions:
+                        - '202005.0'
+                    - title: Reference information- request for quote
+                      url: /docs/scos/dev/user-guides/shop-user-guide/shop-guide-customer-account/references/rfq-reference-i.html
+                      include_versions:
+                        - '202009.0'
+                        - '202108.0'
+                    - title: Reference information- Addresses
+                      url: /docs/scos/dev/user-guides/shop-user-guide/shop-guide-customer-account/references/addresses-refer.html
+                      include_versions:
+                        - '202009.0'
+                        - '202108.0'
+                    - title: Reference information- Shopping carts
+                      url: /docs/scos/dev/user-guides/shop-user-guide/shop-guide-customer-account/references/shop-guide-shop.html
+                      include_versions:
+                        - '202009.0'
+                        - '202108.0'
+                    - title: Reference information- Order history
+                      url: /docs/scos/dev/user-guides/shop-user-guide/shop-guide-customer-account/references/order-history-r.html
+                      include_versions:
+                        - '202009.0'
+                        - '202108.0'
+                    - title: Reference information- Return details
+                      url: /docs/scos/dev/user-guides/shop-user-guide/shop-guide-customer-account/references/return-details-.html
+                      include_versions:
+                        - '202009.0'
+                        - '202108.0'
+                - title: Shop Guide - Wishlists
+                  url: /docs/scos/dev/user-guides/shop-user-guide/shop-guide-customer-account/shop-guide-wish.html
+                  include_versions:
+                    - '202005.0'
+                - title: Shop Guide - Customer Addresses
+                  url: /docs/scos/dev/user-guides/shop-user-guide/shop-guide-customer-account/shop-guide-cust.html
+                  include_versions:
+                    - '202005.0'
+                - title: Shop Guide - Order History
+                  url: /docs/scos/dev/user-guides/shop-user-guide/shop-guide-customer-account/shop-guide-orde.html
+                  include_versions:
+                    - '202005.0'
+                - title: Shop Guide - Newsletter
+                  url: /docs/scos/dev/user-guides/shop-user-guide/shop-guide-customer-account/shop-guide-news.html
+                  include_versions:
+                    - '202005.0'
+                - title: Shop Guide - Shopping Carts
+                  nested:
+                    - title: Shopping Carts
+                      url: /docs/scos/dev/user-guides/shop-user-guide/shop-guide-customer-account/shop-guide-shopping-carts/shop-guide-shop.html
+                      include_versions:
+                        - '202005.0'
+                    - title: Shop Guide - Creating a Shopping Cart
+                      url: /docs/scos/dev/user-guides/shop-user-guide/shop-guide-customer-account/shop-guide-shopping-carts/creating-shoppi.html
+                      include_versions:
+                        - '202005.0'
+                    - title: Shop Guide - Managing a Shopping Cart
+                      url: /docs/scos/dev/user-guides/shop-user-guide/shop-guide-customer-account/shop-guide-shopping-carts/shop-guide-mana.html
+                      include_versions:
+                        - '202005.0'
+                - title: Shop Guide -  Quote Requests
+                  nested:
+                    - title: Shop Guide - Request for Quote
+                      url: /docs/scos/dev/user-guides/shop-user-guide/shop-guide-customer-account/shop-guide-quote-requests/request-for-quo.html
+                      include_versions:
+                        - '202005.0'
+                    - title: Shop Guide - Managing Requests for Quotes for a Sales
+                        Representative
+                      url: /docs/scos/dev/user-guides/shop-user-guide/shop-guide-customer-account/shop-guide-quote-requests/managing-rfqs-s.html
+                      include_versions:
+                        - '202005.0'
+                    - title: Shop Guide - Creating a Request for Quote
+                      url: /docs/scos/dev/user-guides/shop-user-guide/shop-guide-customer-account/shop-guide-quote-requests/creating-rfq-sh.html
+                      include_versions:
+                        - '202005.0'
+                    - title: Shop Guide - Managing Requests for Quotes for a Buyer
+                      url: /docs/scos/dev/user-guides/shop-user-guide/shop-guide-customer-account/shop-guide-quote-requests/managing-rfqs-f.html
+                      include_versions:
+                        - '202005.0'
+                - title: Shop Guide - Returns Management
+                  nested:
+                    - title: Shop Guide - Creating a Return
+                      url: /docs/scos/dev/user-guides/shop-user-guide/shop-guide-customer-account/shop-guide-returns-management/shop-guide-crea.html
+                      include_versions:
+                        - '202005.0'
+                    - title: Shop Guide - Printing a Return Slip
+                      url: /docs/scos/dev/user-guides/shop-user-guide/shop-guide-customer-account/shop-guide-returns-management/shop-guide-prin.html
+                      include_versions:
+                        - '202005.0'
+            - title: Shop guide - Company roles
+              nested:
+                - title: References
+                  nested:
+                    - title: Company Roles- Reference Information
+                      url: /docs/scos/dev/user-guides/shop-user-guide/shop-guide-company-roles/references/company-roles-r.html
+                      include_versions:
+                        - '202005.0'
+                    - title: Reference information- Company roles
+                      url: /docs/scos/dev/user-guides/shop-user-guide/shop-guide-company-roles/references/company-roles-r.html
+                      include_versions:
+                        - '202009.0'
+                        - '202108.0'
+                - title: Shop Guide - Managing Company Roles
+                  url: /docs/scos/dev/user-guides/shop-user-guide/shop-guide-company-roles/company-roles-s.html
+                  include_versions:
+                    - '202005.0'
+                - title: Shop Guide - Creating a New Company Role
+                  url: /docs/scos/dev/user-guides/shop-user-guide/shop-guide-company-roles/shop-guide-crea.html
+                  include_versions:
+                    - '202005.0'
+            - title: Shop Guide - Cancelling Orders
+              url: /docs/scos/dev/user-guides/shop-user-guide/shop-guide-canc.html
+              include_versions:
+                - '202005.0'
+            - title: Shop guide - Searching within CMS pages
+              url: /docs/scos/dev/user-guides/shop-user-guide/searching-withi.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+            - title: Shop guide - Managing products
+              url: /docs/scos/dev/user-guides/shop-user-guide/shop-guide-mana.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+            - title: About shop user guide
+              url: /docs/scos/dev/user-guides/shop-user-guide/about-shop-user.html
+              include_versions:
+                - '202009.0'
+            - title: Comments
+              nested:
+                - title: Shop Guide - Comments
+                  url: /docs/scos/dev/user-guides/shop-user-guide/comments/comments-shop-g.html
+                  include_versions:
+                    - '201907.0'
+                - title: Shop Guide - Managing Comments
+                  url: /docs/scos/dev/user-guides/shop-user-guide/comments/managing-commen.html
+                  include_versions:
+                    - '201907.0'
+            - title: Quotation Proces & RFQ
+              nested:
+                - title: Shop Guide - Request for Quote- Reference Information
+                  url: /docs/scos/dev/user-guides/shop-user-guide/quotation-proces-and-rfq/rfq-reference-i.html
+                  include_versions:
+                    - '201907.0'
+                - title: Shop Guide - Request for Quote
+                  url: /docs/scos/dev/user-guides/shop-user-guide/quotation-proces-and-rfq/request-for-quo.html
+                  include_versions:
+                    - '201907.0'
+                - title: Shop Guide - Managing Requests for Quotes for a Sales
+                    Representative
+                  url: /docs/scos/dev/user-guides/shop-user-guide/quotation-proces-and-rfq/managing-rfqs-s.html
+                  include_versions:
+                    - '201907.0'
+                - title: Shop Guide - Creating a Request for Quote
+                  url: /docs/scos/dev/user-guides/shop-user-guide/quotation-proces-and-rfq/creating-rfq-sh.html
+                  include_versions:
+                    - '201907.0'
+                - title: Shop Guide - Managing Requests for Quotes for a Buyer
+                  url: /docs/scos/dev/user-guides/shop-user-guide/quotation-proces-and-rfq/managing-rfqs-f.html
+                  include_versions:
+                    - '201907.0'
+            - title: Agent Account
+              nested:
+                - title: Shop Guide - Managing Agent Account
+                  url: /docs/scos/dev/user-guides/shop-user-guide/agent-account/shop-guide-mana.html
+                  include_versions:
+                    - '201907.0'
+                - title: Shop Guide - Agent Account
+                  url: /docs/scos/dev/user-guides/shop-user-guide/agent-account/shop-guide-agen.html
+                  include_versions:
+                    - '201907.0'
+            - title: Searching within CMS Pages
+              url: /docs/scos/dev/user-guides/shop-user-guide/searching-withi.html
+              include_versions:
+                - '201903.0'
+                - '201907.0'
+            - title: Shopping Carts
+              nested:
+                - title: Shopping Carts- Reference Information
+                  url: /docs/scos/dev/user-guides/shop-user-guide/shopping-carts/shop-guide-shop.html
+                  include_versions:
+                    - '201907.0'
+                - title: Creating a Shopping Cart
+                  url: /docs/scos/dev/user-guides/shop-user-guide/shopping-carts/creating-shoppi.html
+                  include_versions:
+                    - '201907.0'
+                - title: Managing Shopping Carts
+                  url: /docs/scos/dev/user-guides/shop-user-guide/shopping-carts/shop-guide-mana.html
+                  include_versions:
+                    - '201907.0'
+        - title: About user guides
+          url: /docs/scos/dev/user-guides/about-user-guid.html
+          include_versions:
+            - '202009.0'
+            - '202108.0'
+    - title: Intro to Spryker
+      nested:
+        - title: Spryker videos
+          url: /docs/scos/dev/intro-to-spryker/spryker-videos.html
+          include_versions:
+            - '202009.0'
+            - '202108.0'
+        - title: What's new
+          nested:
+            - title: VAT rates reduction in Germany between July 2020 and January
+                2021
+              url: /docs/scos/dev/intro-to-spryker/whats-new/vat-rates-reduc.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+            - title: Supported versions of PHP
+              url: /docs/scos/dev/intro-to-spryker/whats-new/supported-versi.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+            - title: Documentation updates
+              url: /docs/scos/dev/intro-to-spryker/whats-new/documentation-u.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+            - title: Upcoming major module releases
+              url: /docs/scos/dev/intro-to-spryker/whats-new/upcoming-major-.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+            - title: Security updates
+              url: /docs/scos/dev/intro-to-spryker/whats-new/security-update.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+            - title: What's new
+              url: /docs/scos/dev/intro-to-spryker/whats-new/whats-new.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+            - title: Roadmap
+              url: /docs/scos/dev/intro-to-spryker/whats-new/roadmap.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+            - title: Security audit reports
+              nested:
+                - title: Security audit
+                  url: /docs/scos/dev/intro-to-spryker/whats-new/security-audit-reports/security-audit.html
+                  include_versions:
+                    - '202009.0'
+                    - '202108.0'
+                - title: Penetration test executive summary
+                  url: /docs/scos/dev/intro-to-spryker/whats-new/security-audit-reports/penetration-tes.html
+                  include_versions:
+                    - '202009.0'
+                    - '202108.0'
+        - title: Releases
+          nested:
+            - title: Releases
+              url: /docs/scos/dev/intro-to-spryker/releases/releases.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+            - title: Archive
+              nested:
+                - title: 2017
+                  nested:
+                    - title: Release Notes - May - 2 2017
+                      url: /docs/scos/dev/intro-to-spryker/releases/archive/2017/release-notes-m.html
+                      include_versions:
+                        - '202009.0'
+                        - '202108.0'
+                    - title: Release Notes - August - 2 2017
+                      url: /docs/scos/dev/intro-to-spryker/releases/archive/2017/release-notes-a.html
+                      include_versions:
+                        - '202009.0'
+                        - '202108.0'
+                    - title: Release Notes - December - 2017
+                      url: /docs/scos/dev/intro-to-spryker/releases/archive/2017/release-notes-d.html
+                      include_versions:
+                        - '202009.0'
+                        - '202108.0'
+                    - title: Release Notes - September - 2 2017
+                      url: /docs/scos/dev/intro-to-spryker/releases/archive/2017/release-notes-s.html
+                      include_versions:
+                        - '202009.0'
+                        - '202108.0'
+                    - title: Release Notes - October - 1 2017
+                      url: /docs/scos/dev/intro-to-spryker/releases/archive/2017/release-notes-o.html
+                      include_versions:
+                        - '202009.0'
+                        - '202108.0'
+                    - title: Release Notes - November - 1 2017
+                      url: /docs/scos/dev/intro-to-spryker/releases/archive/2017/release-notes-n.html
+                      include_versions:
+                        - '202009.0'
+                        - '202108.0'
+                    - title: Release Notes - June - 2 2017
+                      url: /docs/scos/dev/intro-to-spryker/releases/archive/2017/release-notes-j.html
+                      include_versions:
+                        - '202009.0'
+                        - '202108.0'
+                - title: 2018
+                  nested:
+                    - title: Release Notes - March - 2018
+                      url: /docs/scos/dev/intro-to-spryker/releases/archive/2018/release-notes-m.html
+                      include_versions:
+                        - '202009.0'
+                        - '202108.0'
+                    - title: Release Notes - February - 1 2018
+                      url: /docs/scos/dev/intro-to-spryker/releases/archive/2018/release-notes-f.html
+                      include_versions:
+                        - '202009.0'
+                        - '202108.0'
+                    - title: Release Notes - April - 2018
+                      url: /docs/scos/dev/intro-to-spryker/releases/archive/2018/release-notes-a.html
+                      include_versions:
+                        - '202009.0'
+                        - '202108.0'
+                    - title: Release Notes - January - 2018
+                      url: /docs/scos/dev/intro-to-spryker/releases/archive/2018/release-notes-j.html
+                      include_versions:
+                        - '202009.0'
+                        - '202108.0'
+            - title: Release notes
+              nested:
+                - title: Release Notes
+                  url: /docs/scos/dev/intro-to-spryker/releases/release-notes/release-notes.html
+                  include_versions:
+                    - '202009.0'
+                    - '202108.0'
+                - title: Release notes 201903.0
+                  nested:
+                    - title: Security Release Notes 201903.0
+                      url: /docs/scos/dev/intro-to-spryker/releases/release-notes/release-notes-201903.0/security-releas.html
+                      include_versions:
+                        - '202009.0'
+                        - '202108.0'
+                    - title: Release Notes 201903.0
+                      url: /docs/scos/dev/intro-to-spryker/releases/release-notes/release-notes-201903.0/release-notes-2.html
+                      include_versions:
+                        - '202009.0'
+                        - '202108.0'
+                - title: Release notes 201907.0
+                  nested:
+                    - title: Security Release Notes 201907.0
+                      url: /docs/scos/dev/intro-to-spryker/releases/release-notes/release-notes-201907.0/security-releas.html
+                      include_versions:
+                        - '202009.0'
+                        - '202108.0'
+                    - title: Release Notes 201907.0
+                      url: /docs/scos/dev/intro-to-spryker/releases/release-notes/release-notes-201907.0/release-notes-2.html
+                      include_versions:
+                        - '202009.0'
+                        - '202108.0'
+                - title: Security release notes- 202102.0 SEC
+                  url: /docs/scos/dev/intro-to-spryker/releases/release-notes/security-releas.html
+                  include_versions:
+                    - '202009.0'
+                    - '202108.0'
+                - title: Release notes 202009.0
+                  nested:
+                    - title: Security release notes- 202009.0
+                      url: /docs/scos/dev/intro-to-spryker/releases/release-notes/release-notes-202009.0/security-releas.html
+                      include_versions:
+                        - '202009.0'
+                        - '202108.0'
+                    - title: Release notes 202009.0
+                      url: /docs/scos/dev/intro-to-spryker/releases/release-notes/release-notes-202009.0/release-notes-2.html
+                      include_versions:
+                        - '202009.0'
+                        - '202108.0'
+                - title: Release Notes 2018.12.0
+                  url: /docs/scos/dev/intro-to-spryker/releases/release-notes/release-notes-2.html
+                  include_versions:
+                    - '202009.0'
+                    - '202108.0'
+                - title: Release notes 202108.0
+                  nested:
+                    - title: Security release notes 202108.0
+                      url: /docs/scos/dev/intro-to-spryker/releases/release-notes/release-notes-202108.0/security-releas.html
+                      include_versions:
+                        - '202108.0'
+                    - title: Release notes 202108.0
+                      url: /docs/scos/dev/intro-to-spryker/releases/release-notes/release-notes-202108.0/release-notes-2.html
+                      include_versions:
+                        - '202108.0'
+                - title: Release notes 2018.11.0
+                  nested:
+                    - title: Security Release Notes 2018.11.0
+                      url: /docs/scos/dev/intro-to-spryker/releases/release-notes/release-notes-2018.11.0/security-releas.html
+                      include_versions:
+                        - '202009.0'
+                        - '202108.0'
+                    - title: Release Notes 2018.11.0
+                      url: /docs/scos/dev/intro-to-spryker/releases/release-notes/release-notes-2018.11.0/release-notes-2.html
+                      include_versions:
+                        - '202009.0'
+                        - '202108.0'
+                - title: 'Release notes Code Releases May, 2020'
+                  nested:
+                    - title: 'Release Notes- Code Releases May, 2020'
+                      url: /docs/scos/dev/intro-to-spryker/releases/release-notes/release-notes-code-releases-may-2020/release-notes-c.html
+                      include_versions:
+                        - '202009.0'
+                        - '202108.0'
+                    - title: 'Security Release Notes- Code Releases May, 2020'
+                      url: /docs/scos/dev/intro-to-spryker/releases/release-notes/release-notes-code-releases-may-2020/security-releas.html
+                      include_versions:
+                        - '202009.0'
+                        - '202108.0'
+                - title: Release notes 202001.0
+                  nested:
+                    - title: Security Release Notes 202001.0
+                      url: /docs/scos/dev/intro-to-spryker/releases/release-notes/release-notes-202001.0/security-releas.html
+                      include_versions:
+                        - '202009.0'
+                        - '202108.0'
+                    - title: Release Notes 202001.0
+                      url: /docs/scos/dev/intro-to-spryker/releases/release-notes/release-notes-202001.0/release-notes-2.html
+                      include_versions:
+                        - '202009.0'
+                        - '202108.0'
+                    - title: Known Issues 202001.0
+                      url: /docs/scos/dev/intro-to-spryker/releases/release-notes/release-notes-202001.0/known-issues-20.html
+                      include_versions:
+                        - '202009.0'
+                        - '202108.0'
+            - title: Releases archive
+              url: /docs/scos/dev/intro-to-spryker/releases/releases-archiv.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+        - title: FAQ
+          url: /docs/scos/dev/intro-to-spryker/faq.html
+          include_versions:
+            - '202009.0'
+            - '202108.0'
+        - title: About Spryker documentation
+          url: /docs/scos/dev/intro-to-spryker/about-documenta.html
+          include_versions:
+            - '202009.0'
+            - '202108.0'
+        - title: Spryker release process
+          url: /docs/scos/dev/intro-to-spryker/spryker-release.html
+          include_versions:
+            - '202009.0'
+            - '202108.0'
+        - title: Support
+          nested:
+            - title: Handling new feature requests
+              url: /docs/scos/dev/intro-to-spryker/support/handling-new-fe.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+            - title: How Spryker Support works
+              url: /docs/scos/dev/intro-to-spryker/support/how-spryker-sup.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+            - title: Getting support
+              url: /docs/scos/dev/intro-to-spryker/support/getting-support.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+            - title: Special- Prepare for a busy season
+              url: /docs/scos/dev/intro-to-spryker/support/special-prepare.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+            - title: Case Escalation
+              url: /docs/scos/dev/intro-to-spryker/support/case-escalation.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+            - title: How to share secrets with the Spryker Support Team
+              url: /docs/scos/dev/intro-to-spryker/support/how-to-share-se.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+            - title: Understanding Project and Core Level Fixes
+              url: /docs/scos/dev/intro-to-spryker/support/understanding-p.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+            - title: Understanding ticket status
+              url: /docs/scos/dev/intro-to-spryker/support/understanding-t.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+            - title: How to get the most out of Spryker Support
+              url: /docs/scos/dev/intro-to-spryker/support/how-to-get-the-.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+            - title: How to use the Support Portal
+              url: /docs/scos/dev/intro-to-spryker/support/how-to-use-the-.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+            - title: Guidelines for new GDPR rules
+              url: /docs/scos/dev/intro-to-spryker/support/guidelines-for-.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+            - title: Understand SLAs
+              url: /docs/scos/dev/intro-to-spryker/support/understand-slas.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+            - title: Handling security issues
+              url: /docs/scos/dev/intro-to-spryker/support/handling-securi.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+            - title: How to contact Spryker Support
+              url: /docs/scos/dev/intro-to-spryker/support/how-to-contact-.html
+              include_versions:
+                - '202009.0'
+                - '202108.0'
+        - title: B2C Suite
+          url: /docs/scos/dev/intro-to-spryker/b2c-suite.html
+          include_versions:
+            - '202009.0'
+            - '202108.0'
+        - title: B2B Suite
+          url: /docs/scos/dev/intro-to-spryker/b2b-suite.html
+          include_versions:
+            - '202009.0'
+            - '202108.0'
+        - title: Master Suite
+          url: /docs/scos/dev/intro-to-spryker/master-suite.html
+          include_versions:
+            - '202009.0'
+            - '202108.0'
+        - title: About Spryker
+          url: /docs/scos/dev/intro-to-spryker/about-spryker.html
+          include_versions:
+            - '202009.0'
+            - '202108.0'
+        - title: MVP project structuring
+          url: /docs/scos/dev/intro-to-spryker/mvp-project-str.html
+          include_versions:
+            - '202009.0'
+            - '202108.0'

--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -1,9 +1,0 @@
-{% assign sidebar_data = site.data.sidebars[page.sidebar].entries %}
-
-{% if page.version %}
-    {% assign current_version = page.version %}
-{% else %}
-    {% assign current_version = site.version %}
-{% endif %}
-
-{% render_sidebar sidebar_data current_version page.url %}

--- a/_includes/topnav.html
+++ b/_includes/topnav.html
@@ -33,10 +33,31 @@
                                     <i class="main-nav__opener-icon icon-arrow-down"></i>
                                 </a>
                                 <ul class="main-nav__drop main-nav__drop--mob-static dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-                                    <li>
-                                        <a href="https://documentation.spryker.com" class="main-nav__drop-link">
-                                        Spryker Commerce OS
+                                    <li class="dropdown">
+                                        <a href="/" class="main-nav__drop-link dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                                            Spryker Commerce OS
+                                            <i class="main-nav__drop-link-arrow icon-arrow-right"></i>
                                         </a>
+                                        <ul class="main-nav__drop dropdown-menu">
+                                            <li>
+                                                <a href="/docs/scos/dev/developer-guides/202108.0/development-guide/about-the-devel.html" class="main-nav__drop-link">
+                                                    <span class="main-nav__drop-link-title">
+                                                        <i class="icon-developer"></i>
+                                                        Developer
+                                                    </span>
+                                                    <span class="main-nav__drop-link-subtitle">SCOS developer guide</span>
+                                                </a>
+                                            </li>
+                                            <li>
+                                                <a href="/docs/scos/user/intro-to-spryker/202108.0/about-documenta.html" class="main-nav__drop-link">
+                                                    <span class="main-nav__drop-link-title">
+                                                        <i class="icon-business"></i>
+                                                        Business User
+                                                    </span>
+                                                    <span class="main-nav__drop-link-subtitle">SCOS users guide</span>
+                                                </a>
+                                            </li>
+                                        </ul>
                                     </li>
                                     <li class="dropdown">
                                         <a href="/" class="main-nav__drop-link dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -48,7 +48,7 @@ layout: default
 
                     {% unless page.hide_sidebar %}
                         <div id="tg-sb-sidebar">
-                            {% include sidebar.html %}
+                            {% render_sidebar %}
                         </div>
                     {% endunless %}
                 </div>

--- a/_plugins/liquid/sidebar.rb
+++ b/_plugins/liquid/sidebar.rb
@@ -24,6 +24,7 @@ module Jekyll
             sidebar_item_title = nested_item['title']
             sidebar_item_url = versionize_url(nested_item['url'])
             include_versions = nested_item['include_versions']
+            sub_items = nested_item['nested']
 
             next nested_item unless include_versions.nil? or include_versions.include? @version
 
@@ -35,20 +36,22 @@ module Jekyll
         <strong class="sidebar-nav__title">#{sidebar_item_title}</strong>
     </a>
 EOF
-            elsif sidebar_item_url == @page_url then
-                sidebar_string += <<-EOF
-<li class="active-page-item">
-    <a title="#{sidebar_item_title}" href="#{sidebar_item_url}" class="sidebar-nav__link">#{sidebar_item_title}</a>
-EOF
             else
                 sidebar_string += <<-EOF
-<li>
-    <a title="#{sidebar_item_title}" href="#{sidebar_item_url}" class="sidebar-nav__link">#{sidebar_item_title}</a>
+<li#{' class="active-page-item"' if sidebar_item_url == @page_url}>
+    <a title="#{sidebar_item_title}" href="#{sidebar_item_url}" class="sidebar-nav__link#{' sidebar-nav__link--shifted' unless sidebar_item_url.nil? || sub_items.nil? }">#{sidebar_item_title}</a>
 EOF
+                unless sidebar_item_url.nil? || sub_items.nil?
+                    sidebar_string += <<-EOF
+    <a href="#" class="sidebar-nav__opener sidebar-nav__opener--small">
+        <i class="icon-arrow-right"></i>
+    </a>
+EOF
+                end
             end
 
-            if not nested_item['nested'].nil? then
-                sidebar_string += '<ul>' + build_sidebar_string(nested_item['nested']) + '</ul>'
+            if not sub_items.nil? then
+                sidebar_string += '<ul>' + build_sidebar_string(sub_items) + '</ul>'
             end
             sidebar_string += '</li>'
         end

--- a/_plugins/liquid/sidebar.rb
+++ b/_plugins/liquid/sidebar.rb
@@ -7,15 +7,30 @@ module Jekyll
     end
 
     def render(context)
-      @context = context
-      data = @markup.split(" ")
-      sidebar_data = @context[data[0].strip][0]
-      @version = @context[data[1].strip]
-      @page_url = @context[data[2].strip]
+        @context = context
+        @version = get_current_version
+        @page_url = get_page_url
+        sidebar_data = get_sidebar_data
 
-      return '' if sidebar_data.nil? or sidebar_data['nested'].nil?
+        return '' if sidebar_data.nil? or sidebar_data['nested'].nil?
 
-      '<ul class="sidebar-nav">' + build_sidebar_string(sidebar_data['nested']) + '</ul>'
+        '<ul class="sidebar-nav">' + build_sidebar_string(sidebar_data['nested']) + '</ul>'
+    end
+
+    def get_current_version()
+        !@context['page']['version'].nil? ? @context['page']['version'] : @context['site']['version']
+    end
+
+    def get_page_url()
+        @context['page']['url']
+    end
+
+    def get_sidebar_name()
+        @context['page']['sidebar']
+    end
+
+    def get_sidebar_data()
+        @context['site']['data']['sidebars'][get_sidebar_name]['entries'][0]
     end
 
     def build_sidebar_string(sidebar_data)

--- a/_plugins/page_versions.rb
+++ b/_plugins/page_versions.rb
@@ -28,7 +28,7 @@ def get_versions(versioned_page_urls)
     end
 end
 
-def is_multiversion(page)
+def can_be_versioned(page)
     product = page['product']
     role = page['role']
     versioned_categories = page.site.config['versioned_categories']
@@ -48,7 +48,7 @@ end
 Jekyll::Hooks.register :pages, :pre_render do |page, config|
     next page unless File.extname(page.path).match?(/md|html/)
     next page unless page.url.start_with? '/docs/'
-    next page unless is_multiversion page
+    next page unless can_be_versioned page
 
     setup_current_page_version page, config
     setup_all_page_versions page, config


### PR DESCRIPTION
- Added new scopes for `SCOS` product
- Adjusted top navigation to have the `SCOS` dropdown among products
- Refactored and optimised sidebar, got rid of `include` to increase performance
- Added sidebar data for `scos/user` and `scos/dev` realms
- Installed `liquid-c` and `jekyll-include-cache` for performance reasons
- Added separate config for production environment and adjusted `.travis.yml` accordingly